### PR TITLE
feat: add DBF table loader and catalog integration

### DIFF
--- a/src/XBase.Core/Table/DbfMetadata.cs
+++ b/src/XBase.Core/Table/DbfMetadata.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using XBase.Abstractions;
 
@@ -48,7 +49,10 @@ public sealed class DbfTableDescriptor : ITableDescriptor
     FieldSchemas = fieldSchemas.ToArray();
     Sidecars = sidecars ?? DbfSidecarManifest.Empty;
     Fields = FieldSchemas.Select(schema => schema.ToDescriptor()).ToArray();
-    Indexes = Array.Empty<IIndexDescriptor>();
+    Indexes = Sidecars.IndexFileNames
+      .Select(CreateIndexDescriptor)
+      .Cast<IIndexDescriptor>()
+      .ToArray();
   }
 
   public string Name { get; }
@@ -74,4 +78,10 @@ public sealed class DbfTableDescriptor : ITableDescriptor
   public IReadOnlyList<DbfFieldSchema> FieldSchemas { get; }
 
   public DbfSidecarManifest Sidecars { get; }
+
+  private static IndexDescriptor CreateIndexDescriptor(string fileName)
+  {
+    string name = Path.GetFileNameWithoutExtension(fileName) ?? fileName;
+    return new IndexDescriptor(name, string.Empty, false, fileName);
+  }
 }

--- a/src/XBase.Core/Table/IndexDescriptor.cs
+++ b/src/XBase.Core/Table/IndexDescriptor.cs
@@ -4,11 +4,12 @@ namespace XBase.Core.Table;
 
 public sealed class IndexDescriptor : IIndexDescriptor
 {
-  public IndexDescriptor(string name, string expression, bool isDescending)
+  public IndexDescriptor(string name, string expression, bool isDescending, string? fileName = null)
   {
     Name = name;
     Expression = expression;
     IsDescending = isDescending;
+    FileName = fileName;
   }
 
   public string Name { get; }
@@ -16,4 +17,6 @@ public sealed class IndexDescriptor : IIndexDescriptor
   public string Expression { get; }
 
   public bool IsDescending { get; }
+
+  public string? FileName { get; }
 }

--- a/src/XBase.Core/Table/TableCatalog.cs
+++ b/src/XBase.Core/Table/TableCatalog.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using XBase.Abstractions;
 
 namespace XBase.Core.Table;
 
@@ -17,7 +18,7 @@ public sealed class TableCatalog
     this.loader = loader ?? throw new ArgumentNullException(nameof(loader));
   }
 
-  public IReadOnlyList<DbfTableDescriptor> EnumerateTables(string directoryPath)
+  public IReadOnlyList<ITableDescriptor> EnumerateTables(string directoryPath)
   {
     if (directoryPath is null)
     {
@@ -29,7 +30,7 @@ public sealed class TableCatalog
       throw new DirectoryNotFoundException($"Directory '{directoryPath}' was not found.");
     }
 
-    List<DbfTableDescriptor> tables = new();
+    List<ITableDescriptor> tables = new();
     foreach (string dbfPath in Directory.EnumerateFiles(directoryPath, "*.dbf", SearchOption.TopDirectoryOnly))
     {
       tables.Add(loader.Load(dbfPath));


### PR DESCRIPTION
## Summary
- add a DBF table loader that can parse headers from file paths or streams and exposes memo/index sidecars
- surface index descriptors, update the catalog entry point, and adjust tooling/tests to consume the richer metadata

## Testing
- dotnet test xBase.sln --configuration Release --no-build

------
https://chatgpt.com/codex/tasks/task_e_68dc79e112e483228669437989ce50e7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Load tables directly from a stream with a specified table name.
  - Table catalog now returns a generic table descriptor, enabling broader format support.
  - Index metadata now includes names and optional file paths for clearer identification.

- Improvements
  - More robust field descriptor parsing and index discovery.
  - CLI tool outputs enhanced: generic table handling, conditional DBF details, and clearer index listings with names/expressions.

- Tests
  - Added tests for stream-based loading and updated index handling.
  - Adjusted tests for the new generic table enumeration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->