### PR TITLE
feat: expose DBF loader descriptors via interface

### DIFF
--- a/src/XBase.Core/Table/DbfTableLoader.cs
+++ b/src/XBase.Core/Table/DbfTableLoader.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using XBase.Abstractions;
 
 namespace XBase.Core.Table;
 
@@ -12,7 +13,9 @@ public sealed class DbfTableLoader
   private static readonly string[] MemoExtensions = [".dbt", ".fpt"];
   private static readonly string[] IndexExtensions = [".ndx", ".ntx", ".mdx"];
 
-  public DbfTableDescriptor Load(string filePath)
+  public ITableDescriptor Load(string filePath) => LoadDbf(filePath);
+
+  public DbfTableDescriptor LoadDbf(string filePath)
   {
     if (filePath is null)
     {
@@ -27,10 +30,13 @@ public sealed class DbfTableLoader
     using FileStream stream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
     string tableName = Path.GetFileNameWithoutExtension(filePath) ?? Path.GetFileName(filePath);
     string? directory = Path.GetDirectoryName(filePath);
-    return Load(stream, tableName, directory);
+    return LoadDbf(stream, tableName, directory);
   }
 
-  public DbfTableDescriptor Load(Stream stream, string tableName, string? directoryPath = null)
+  public ITableDescriptor Load(Stream stream, string tableName, string? directoryPath = null) =>
+    LoadDbf(stream, tableName, directoryPath);
+
+  public DbfTableDescriptor LoadDbf(Stream stream, string tableName, string? directoryPath = null)
   {
     if (stream is null)
     {

--- a/src/XBase.Tools/Program.cs
+++ b/src/XBase.Tools/Program.cs
@@ -106,7 +106,7 @@ static Task<int> DbfInfoAsync(Queue<string> arguments)
 
   if (File.Exists(target))
   {
-    DbfTableDescriptor table = loader.Load(target);
+    DbfTableDescriptor table = loader.LoadDbf(target);
     PrintTable(table, target);
     return Task.FromResult(0);
   }

--- a/tests/XBase.Core.Tests/DbfFixtureLibrary.cs
+++ b/tests/XBase.Core.Tests/DbfFixtureLibrary.cs
@@ -19,6 +19,7 @@ internal static class DbfFixtureLibrary
         RecordLength: 25,
         RecordCount: 12,
         FieldCount: 2,
+        LastUpdated: new DateOnly(2024, 3, 15),
         Base64Payload:
           "A3wDDwwAAABhABkAAAAAAAAAAAAAAAAAAAAAAAADAABJRAAAAAAAAAAAAE4AAAAABAAAAAAAAAAAAAAAAAAAAE5B" +
           "TUUAAAAAAAAAQwAAAAAUAAIAAAAAAAAAAAAAAAAADQ=="),
@@ -31,6 +32,7 @@ internal static class DbfFixtureLibrary
         RecordLength: 17,
         RecordCount: 3,
         FieldCount: 2,
+        LastUpdated: new DateOnly(2023, 7, 5),
         Base64Payload:
           "g3sHBQMAAABhABEAAAAAAAAAAAAAAAAAAAAAAABXAABET0NJRAAAAAAAAE4AAAAABgAAAAAAAAAAAAAAAAAAAE5P" +
           "VEUAAAAAAAAATQAAAAAKAAAAAAAAAAAAAAAAAAAADQ=="),
@@ -43,6 +45,7 @@ internal static class DbfFixtureLibrary
         RecordLength: 22,
         RecordCount: 7,
         FieldCount: 3,
+        LastUpdated: new DateOnly(2022, 11, 30),
         Base64Payload:
           "MHoLHgcAAACBABYAAAAAAAAAAAAAAAAAAAAAAADJAABDT0RFAAAAAAAAAEMAAAAADAAAAAAAAAAAAAAAAAAAAEFD" +
           "VElWRQAAAAAATAAAAAABAAAAAAAAAAAAAAAAAAAAQU1PVU5UAAAAAABOAAAAAAgCAAAAAAAAAAAAAAAAAAAN")
@@ -71,6 +74,7 @@ public sealed record DbfFixtureDescriptor(
   ushort RecordLength,
   uint RecordCount,
   int FieldCount,
+  DateOnly LastUpdated,
   string Base64Payload)
 {
   public string EnsureMaterialized()

--- a/tests/XBase.Core.Tests/DbfTableLoaderTests.cs
+++ b/tests/XBase.Core.Tests/DbfTableLoaderTests.cs
@@ -25,13 +25,14 @@ public sealed class DbfTableLoaderTests
     string path = fixture.EnsureMaterialized();
     var loader = new DbfTableLoader();
 
-    DbfTableDescriptor descriptor = loader.Load(path);
+    DbfTableDescriptor descriptor = loader.LoadDbf(path);
 
     Assert.Equal(fixture.Version, descriptor.Version);
     Assert.Equal(fixture.LanguageDriverId, descriptor.LanguageDriverId);
     Assert.Equal(fixture.HeaderLength, descriptor.HeaderLength);
     Assert.Equal(fixture.RecordLength, descriptor.RecordLength);
     Assert.Equal(fixture.RecordCount, descriptor.RecordCount);
+    Assert.Equal(fixture.LastUpdated, descriptor.LastUpdated);
     Assert.Equal(fixture.FieldCount, descriptor.Fields.Count);
   }
 
@@ -54,7 +55,7 @@ public sealed class DbfTableLoaderTests
 
     var loader = new DbfTableLoader();
 
-    DbfTableDescriptor descriptor = loader.Load(tablePath);
+    DbfTableDescriptor descriptor = loader.LoadDbf(tablePath);
 
     Assert.Equal(Path.GetFileName(memoPath), descriptor.MemoFileName);
     Assert.Contains(Path.GetFileName(ntxPath), descriptor.Sidecars.IndexFileNames);
@@ -79,7 +80,7 @@ public sealed class DbfTableLoaderTests
     var loader = new DbfTableLoader();
 
     using FileStream stream = File.OpenRead(tablePath);
-    DbfTableDescriptor descriptor = loader.Load(stream, tableName, workspace.DirectoryPath);
+    DbfTableDescriptor descriptor = loader.LoadDbf(stream, tableName, workspace.DirectoryPath);
 
     Assert.Equal(fixture.Version, descriptor.Version);
     Assert.Equal(fixture.RecordCount, descriptor.RecordCount);


### PR DESCRIPTION
## Summary
- add interface-oriented overloads to `DbfTableLoader` while keeping strongly typed helpers
- extend DBF fixtures/tests to assert last update metadata from parsed headers
- update tooling entry point to use the strongly typed loader overload

## Testing
- dotnet test tests/XBase.Core.Tests/XBase.Core.Tests.csproj --configuration Release

------
https://chatgpt.com/codex/tasks/task_e_68dc80f09718832292a2f723ae92d4e0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added explicit DBF loading methods for file paths and streams, improving clarity when working with DBF tables.

- Refactor
  - General Load methods now return an interface type for broader compatibility, with no functional changes.

- Tools
  - Updated the command-line tool to use the new DBF-specific loader; behavior remains the same for users.

- Tests
  - Expanded test fixtures with LastUpdated metadata.
  - Updated tests to use the new DBF-specific loader methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->