### PR TITLE
feat: resolve DBF encoding from language driver

### DIFF
--- a/src/XBase.Core/Table/DbfEncodingRegistry.cs
+++ b/src/XBase.Core/Table/DbfEncodingRegistry.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace XBase.Core.Table;
+
+internal static class DbfEncodingRegistry
+{
+  private static readonly IReadOnlyDictionary<byte, int> CodePageByLanguageDriverId =
+    new Dictionary<byte, int>
+    {
+      { 0x01, 437 },   // US MS-DOS
+      { 0x02, 850 },   // International MS-DOS
+      { 0x03, 1252 },  // Windows ANSI
+      { 0x57, 1252 },  // ANSI (dBASE IV)
+      { 0x64, 852 },   // Eastern European MS-DOS
+      { 0x65, 857 },   // Turkish MS-DOS
+      { 0x66, 866 },   // Russian MS-DOS
+      { 0x67, 865 },   // Nordic MS-DOS
+      { 0x68, 861 },   // Icelandic MS-DOS
+      { 0x69, 895 },   // Czech MS-DOS
+      { 0x6A, 620 },   // Mazovia (Polish) MS-DOS
+      { 0x6B, 737 },   // Greek MS-DOS
+      { 0x78, 950 },   // Chinese (Traditional) Windows/DOS
+      { 0x79, 949 },   // Korean Windows/DOS
+      { 0x7A, 936 },   // Chinese (Simplified) Windows/DOS
+      { 0x7B, 932 },   // Japanese Windows/DOS
+      { 0x7C, 874 },   // Thai Windows
+      { 0x7D, 1255 },  // Hebrew Windows
+      { 0x7E, 1256 },  // Arabic Windows
+      { 0x96, 10007 }, // Russian Macintosh
+      { 0x97, 10029 }, // Mac Latin 2
+      { 0x98, 10006 }, // Mac Greek I
+      { 0x99, 10081 }, // Mac Turkish
+      { 0xC8, 1250 },  // Eastern European Windows
+      { 0xC9, 1251 },  // Russian Windows
+      { 0xCA, 1254 },  // Turkish Windows
+      { 0xCB, 1253 },  // Greek Windows
+      { 0xCC, 1257 },  // Baltic Windows
+      { 0xCD, 1252 },  // Windows ANSI (FoxPro)
+    };
+
+  private static readonly Encoding DefaultEncoding = Encoding.ASCII;
+
+  static DbfEncodingRegistry()
+  {
+    Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+  }
+
+  public static Encoding Resolve(byte languageDriverId)
+  {
+    if (CodePageByLanguageDriverId.TryGetValue(languageDriverId, out int codePage))
+    {
+      try
+      {
+        return Encoding.GetEncoding(codePage);
+      }
+      catch (ArgumentException)
+      {
+      }
+      catch (NotSupportedException)
+      {
+      }
+    }
+
+    return DefaultEncoding;
+  }
+}

--- a/src/XBase.Core/XBase.Core.csproj
+++ b/src/XBase.Core/XBase.Core.csproj
@@ -6,6 +6,10 @@
     <ProjectReference Include="..\XBase.Expressions\XBase.Expressions.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/XBase.Core.Tests/DbfFixtureLibrary.cs
+++ b/tests/XBase.Core.Tests/DbfFixtureLibrary.cs
@@ -48,7 +48,19 @@ internal static class DbfFixtureLibrary
         LastUpdated: new DateOnly(2022, 11, 30),
         Base64Payload:
           "MHoLHgcAAACBABYAAAAAAAAAAAAAAAAAAAAAAADJAABDT0RFAAAAAAAAAEMAAAAADAAAAAAAAAAAAAAAAAAAAEFD" +
-          "VElWRQAAAAAATAAAAAABAAAAAAAAAAAAAAAAAAAAQU1PVU5UAAAAAABOAAAAAAgCAAAAAAAAAAAAAAAAAAAN")
+          "VElWRQAAAAAATAAAAAABAAAAAAAAAAAAAAAAAAAAQU1PVU5UAAAAAABOAAAAAAgCAAAAAAAAAAAAAAAAAAAN"),
+      new DbfFixtureDescriptor(
+        "dBASE_III_CP852",
+        "dBASE_III_CP852.dbf",
+        Version: 0x03,
+        LanguageDriverId: 0x64,
+        HeaderLength: 65,
+        RecordLength: 11,
+        RecordCount: 0,
+        FieldCount: 1,
+        LastUpdated: new DateOnly(2024, 4, 1),
+        Base64Payload:
+          "A3wEAQAAAABBAAsAAAAAAAAAAAAAAAAAAAAAAABkAACsoXNsbwAAAAAAAEMAAAAACgACAAAAAAAAAAAAAAAAAA0=")
     ];
 
   public static IEnumerable<DbfFixtureDescriptor> All => Fixtures;

--- a/tests/XBase.Core.Tests/DbfTableLoaderTests.cs
+++ b/tests/XBase.Core.Tests/DbfTableLoaderTests.cs
@@ -87,4 +87,17 @@ public sealed class DbfTableLoaderTests
     Assert.Equal(Path.GetFileName(memoPath), descriptor.MemoFileName);
     Assert.Empty(descriptor.Sidecars.IndexFileNames);
   }
+
+  [Fact]
+  public void Load_WithCodePage852FieldNames_ResolvesEncoding()
+  {
+    DbfFixtureDescriptor fixture = DbfFixtureLibrary.Get("dBASE_III_CP852");
+    string path = fixture.EnsureMaterialized();
+    var loader = new DbfTableLoader();
+
+    DbfTableDescriptor descriptor = loader.LoadDbf(path);
+
+    Assert.Equal("Číslo", descriptor.FieldSchemas.Single().Name);
+    Assert.Equal("Číslo", descriptor.Fields.Single().Name);
+  }
 }


### PR DESCRIPTION
## Summary
- add a language driver to encoding registry for DBF tables and register code page providers
- resolve field name encoding in `DbfTableLoader` using the detected code page
- extend fixtures and tests to cover non-ASCII field names encoded via CP852

## Testing
- dotnet test tests/XBase.Core.Tests/XBase.Core.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68dccededf9c83229c734e0ad69459f6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic character encoding resolution for DBF files based on language driver IDs.
  - Correct decoding of non-ASCII field names (e.g., Central European characters), improving display and data readability.
  - Graceful fallback to a default encoding when an unknown mapping is encountered.

- Tests
  - Added coverage to verify proper decoding of field names using CP852.

- Chores
  - Included encoding provider dependency to support additional code pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->