### PR TITLE
test(core): assert dbf schema metadata

### DIFF
--- a/tests/XBase.Core.Tests/DbfFieldAssertions.cs
+++ b/tests/XBase.Core.Tests/DbfFieldAssertions.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using XBase.Abstractions;
+using XBase.Core.Table;
+using Xunit;
+
+namespace XBase.Core.Tests;
+
+internal static class DbfFieldAssertions
+{
+  public static void Equal(DbfFieldSchema expected, DbfFieldSchema actual)
+  {
+    Assert.NotNull(actual);
+    Assert.Equal(expected.Name, actual.Name);
+    Assert.Equal(expected.Type, actual.Type);
+    Assert.Equal(expected.Length, actual.Length);
+    Assert.Equal(expected.DecimalCount, actual.DecimalCount);
+    Assert.Equal(expected.IsNullable, actual.IsNullable);
+  }
+
+  public static void Equal(DbfFieldSchema expected, IFieldDescriptor actual)
+  {
+    Assert.NotNull(actual);
+    Assert.Equal(expected.Name, actual.Name);
+    Assert.Equal(expected.Type.ToString(), actual.Type);
+    Assert.Equal(expected.Length, actual.Length);
+    Assert.Equal(expected.DecimalCount, actual.DecimalCount);
+    Assert.Equal(expected.IsNullable, actual.IsNullable);
+  }
+
+  public static void SequenceEqual(IReadOnlyList<DbfFieldSchema> expected, IReadOnlyList<DbfFieldSchema> actual)
+  {
+    Assert.Equal(expected.Count, actual.Count);
+    for (int index = 0; index < expected.Count; index++)
+    {
+      Equal(expected[index], actual[index]);
+    }
+  }
+
+  public static void SequenceEqual(IReadOnlyList<DbfFieldSchema> expected, IReadOnlyList<IFieldDescriptor> actual)
+  {
+    Assert.Equal(expected.Count, actual.Count);
+    for (int index = 0; index < expected.Count; index++)
+    {
+      Equal(expected[index], actual[index]);
+    }
+  }
+}

--- a/tests/XBase.Core.Tests/DbfTableLoaderTests.cs
+++ b/tests/XBase.Core.Tests/DbfTableLoaderTests.cs
@@ -34,6 +34,10 @@ public sealed class DbfTableLoaderTests
     Assert.Equal(fixture.RecordCount, descriptor.RecordCount);
     Assert.Equal(fixture.LastUpdated, descriptor.LastUpdated);
     Assert.Equal(fixture.FieldCount, descriptor.Fields.Count);
+
+    var expectedSchemas = fixture.ExpectedFields;
+    DbfFieldAssertions.SequenceEqual(expectedSchemas, descriptor.FieldSchemas);
+    DbfFieldAssertions.SequenceEqual(expectedSchemas, descriptor.Fields);
   }
 
   [Fact]


### PR DESCRIPTION
## Summary
- embed expected field schema metadata alongside the DBF fixtures used by the loader tests
- verify loader output for field schemas and descriptors against the fixture expectations
- add reusable assertions to compare parsed DBF schemas with generic field descriptors

## Testing
- dotnet test tests/XBase.Core.Tests/XBase.Core.Tests.csproj -c Release --filter Load_FromFile_ParsesHeader

------
https://chatgpt.com/codex/tasks/task_e_68dcd14c92048322b2efe409d08a3984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added reusable assertions to compare expected and actual DBF field schemas and collections.
  * Extended fixtures to include explicit expected field definitions with enforced count consistency.
  * Enhanced header parsing tests to validate field schemas against fixture expectations in multiple representations.
  * Updated existing test data to provide complete field metadata for verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->