### PR TITLE
fix: default DBF encoding fallback for undefined language driver

### DIFF
--- a/src/XBase.Core/Table/DbfEncodingRegistry.cs
+++ b/src/XBase.Core/Table/DbfEncodingRegistry.cs
@@ -9,6 +9,7 @@ internal static class DbfEncodingRegistry
   private static readonly IReadOnlyDictionary<byte, int> CodePageByLanguageDriverId =
     new Dictionary<byte, int>
     {
+      { 0x00, 437 },  // Undefined (defaults to US MS-DOS)
       { 0x01, 437 },   // US MS-DOS
       { 0x02, 850 },   // International MS-DOS
       { 0x03, 1252 },  // Windows ANSI
@@ -40,11 +41,18 @@ internal static class DbfEncodingRegistry
       { 0xCD, 1252 },  // Windows ANSI (FoxPro)
     };
 
-  private static readonly Encoding DefaultEncoding = Encoding.ASCII;
+  private static readonly Encoding DefaultEncoding;
 
   static DbfEncodingRegistry()
   {
     Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+    if (!CodePageByLanguageDriverId.TryGetValue(0x00, out int fallbackCodePage))
+    {
+      fallbackCodePage = 437;
+    }
+
+    DefaultEncoding = Encoding.GetEncoding(fallbackCodePage);
   }
 
   public static Encoding Resolve(byte languageDriverId)

--- a/tests/XBase.Core.Tests/DbfFixtureLibrary.cs
+++ b/tests/XBase.Core.Tests/DbfFixtureLibrary.cs
@@ -81,6 +81,21 @@ internal static class DbfFixtureLibrary
         ExpectedFields:
           [
             new DbfFieldSchema("Číslo", 'C', 10, 0, true)
+          ]),
+      new DbfFixtureDescriptor(
+        "dBASE_III_DefaultLdid",
+        "dBASE_III_DefaultLdid.dbf",
+        Version: 0x03,
+        LanguageDriverId: 0x00,
+        HeaderLength: 65,
+        RecordLength: 11,
+        RecordCount: 0,
+        FieldCount: 1,
+        LastUpdated: new DateOnly(2024, 5, 1),
+        Base64Payload: "A3wFAQAAAABBAAsAAAAAAAAAAAAAAAAAAAAAAAAAAACOUEZFTAAAAAAAAEMAAAAACgAAAAAAAAAAAAAAAAAAAA0=",
+        ExpectedFields:
+          [
+            new DbfFieldSchema("ÄPFEL", 'C', 10, 0, false)
           ])
     ];
 

--- a/tests/XBase.Core.Tests/DbfTableLoaderTests.cs
+++ b/tests/XBase.Core.Tests/DbfTableLoaderTests.cs
@@ -104,4 +104,17 @@ public sealed class DbfTableLoaderTests
     Assert.Equal("Číslo", descriptor.FieldSchemas.Single().Name);
     Assert.Equal("Číslo", descriptor.Fields.Single().Name);
   }
+
+  [Fact]
+  public void Load_WithDefaultLanguageDriverId_FallsBackToCodePage437()
+  {
+    DbfFixtureDescriptor fixture = DbfFixtureLibrary.Get("dBASE_III_DefaultLdid");
+    string path = fixture.EnsureMaterialized();
+    var loader = new DbfTableLoader();
+
+    DbfTableDescriptor descriptor = loader.LoadDbf(path);
+
+    Assert.Equal("ÄPFEL", descriptor.FieldSchemas.Single().Name);
+    Assert.Equal("ÄPFEL", descriptor.Fields.Single().Name);
+  }
 }


### PR DESCRIPTION
## Summary
- add CP437 mapping for language driver 0x00 and use it for encoding fallback
- extend DBF fixtures with a default language driver sample covering extended OEM characters
- verify decoding through a new loader test that asserts CP437 field names

## Testing
- `dotnet test xBase.sln --configuration Release`


------
https://chatgpt.com/codex/tasks/task_e_68dcd4a52ecc8322a2fd063d8a0ee489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected default encoding for DBF files with undefined language driver ID (0x00) by falling back to Code Page 437, ensuring non-ASCII field names display correctly (e.g., ÄPFEL).

* **Tests**
  * Added a new dBASE III fixture with default language driver ID and a test validating fallback to Code Page 437.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->