### PR TITLE
fix: normalize DBF sidecar discovery for relative paths

### DIFF
--- a/src/XBase.Core/Table/DbfTableLoader.cs
+++ b/src/XBase.Core/Table/DbfTableLoader.cs
@@ -27,9 +27,15 @@ public sealed class DbfTableLoader
       throw new FileNotFoundException("DBF file was not found.", filePath);
     }
 
-    using FileStream stream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-    string tableName = Path.GetFileNameWithoutExtension(filePath) ?? Path.GetFileName(filePath);
-    string? directory = Path.GetDirectoryName(filePath);
+    string normalizedPath = Path.GetFullPath(filePath);
+
+    using FileStream stream = new(normalizedPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+    string tableName = Path.GetFileNameWithoutExtension(normalizedPath) ?? Path.GetFileName(normalizedPath);
+    string? directory = Path.GetDirectoryName(normalizedPath);
+    if (string.IsNullOrEmpty(directory))
+    {
+      directory = Directory.GetCurrentDirectory();
+    }
     return LoadDbf(stream, tableName, directory);
   }
 


### PR DESCRIPTION
## Summary
- resolve DBF file paths to absolute locations before probing for sidecars so relative paths use the workspace directory
- add a regression test that exercises memo/index detection when loading via a relative path

## Testing
- dotnet test tests/XBase.Core.Tests/XBase.Core.Tests.csproj --configuration Release


------
https://chatgpt.com/codex/tasks/task_e_68dcd9765e8083229654862bfba4f2a5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of relative file paths when opening tables, ensuring memo and index sidecar files are reliably detected.
  * Normalizes file paths for consistent table name and directory resolution.
  * Falls back to the current working directory when a directory cannot be derived, reducing load errors in edge cases.

* **Tests**
  * Added coverage verifying successful loading via relative paths and detection of companion memo/index files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->