### PR TITLE
fix: ensure transactions start journal

### DIFF
--- a/src/XBase.Data/Providers/XBaseTransaction.cs
+++ b/src/XBase.Data/Providers/XBaseTransaction.cs
@@ -12,10 +12,14 @@ public sealed class XBaseTransaction : DbTransaction
   private readonly IJournal _journal;
   private bool _disposed;
 
-  public XBaseTransaction(XBaseConnection connection, IJournal journal)
+  public XBaseTransaction(XBaseConnection connection, IJournal journal, bool journalStarted = false)
   {
     _connection = connection;
     _journal = journal;
+    if (!journalStarted)
+    {
+      _journal.BeginAsync().GetAwaiter().GetResult();
+    }
   }
 
   public override IsolationLevel IsolationLevel => IsolationLevel.ReadCommitted;

--- a/tasks.md
+++ b/tasks.md
@@ -16,6 +16,7 @@
 - [ ] Wire table mutators to support insert/update/delete against in-memory row buffers (beyond no-op stubs).
 
 ## M4 – Journaling & Transactions ⏳
+- [x] Ensured `XBaseConnection` starts the journal for synchronous and asynchronous transactions with test coverage.
 - [ ] Design and implement the WAL journal format covering FR-WT-1 – FR-WT-4 requirements with crash-recovery tests.
 - [ ] Introduce lock coordination (file + optional record locks) and acceptance tests simulating concurrent access.
 - [ ] Implement deferred index maintenance hooks to enable safe reindex/pack flows.

--- a/tests/XBase.Data.Tests/XBaseConnectionTests.cs
+++ b/tests/XBase.Data.Tests/XBaseConnectionTests.cs
@@ -1,4 +1,8 @@
 using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using XBase.Abstractions;
+using XBase.Core.Cursors;
 using XBase.Data.Providers;
 
 namespace XBase.Data.Tests;
@@ -13,5 +17,53 @@ public sealed class XBaseConnectionTests
     connection.Open();
 
     Assert.Equal(ConnectionState.Open, connection.State);
+  }
+
+  [Fact]
+  public void BeginTransaction_StartsJournal()
+  {
+    var journal = new FakeJournal();
+    using var connection = new XBaseConnection(new NoOpCursorFactory(), journal);
+
+    using var transaction = connection.BeginTransaction();
+
+    Assert.Equal(1, journal.BeginCallCount);
+    Assert.Equal(CancellationToken.None, journal.LastBeginCancellationToken);
+  }
+
+  [Fact]
+  public async Task BeginTransactionAsync_StartsJournal()
+  {
+    var journal = new FakeJournal();
+    using var connection = new XBaseConnection(new NoOpCursorFactory(), journal);
+
+    await using var transaction = await connection.BeginTransactionAsync();
+
+    Assert.Equal(1, journal.BeginCallCount);
+    Assert.Equal(CancellationToken.None, journal.LastBeginCancellationToken);
+  }
+
+  private sealed class FakeJournal : IJournal
+  {
+    public int BeginCallCount { get; private set; }
+
+    public CancellationToken LastBeginCancellationToken { get; private set; } = CancellationToken.None;
+
+    public ValueTask BeginAsync(CancellationToken cancellationToken = default)
+    {
+      BeginCallCount++;
+      LastBeginCancellationToken = cancellationToken;
+      return ValueTask.CompletedTask;
+    }
+
+    public ValueTask CommitAsync(CancellationToken cancellationToken = default)
+    {
+      return ValueTask.CompletedTask;
+    }
+
+    public ValueTask RollbackAsync(CancellationToken cancellationToken = default)
+    {
+      return ValueTask.CompletedTask;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- ensure `XBaseConnection` triggers journal begin for synchronous and asynchronous transactions
- allow `XBaseTransaction` to skip re-starting journals when already active and cover via tests
- record the journaling progress in `tasks.md`

## Testing
- dotnet test tests/XBase.Data.Tests/XBase.Data.Tests.csproj --configuration Release

------
https://chatgpt.com/codex/tasks/task_e_68dcda97ebe4832282c83b706f91bea8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added asynchronous transaction initiation with BeginTransactionAsync overloads.
- Improvements
  - Ensures the transaction journal starts exactly once for both sync and async flows.
  - Reduces blocking during transaction start by leveraging async operations.
- Tests
  - Added coverage verifying journal start behavior and cancellation token handling for sync/async transactions.
- Documentation
  - Updated project tasks to reflect completed journaling and transaction work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->