### PR TITLE
fix: rollback journals when disposing uncommitted transactions

### DIFF
--- a/src/XBase.Data/Providers/XBaseTransaction.cs
+++ b/src/XBase.Data/Providers/XBaseTransaction.cs
@@ -11,6 +11,7 @@ public sealed class XBaseTransaction : DbTransaction
   private readonly XBaseConnection _connection;
   private readonly IJournal _journal;
   private bool _disposed;
+  private bool _completed;
 
   public XBaseTransaction(XBaseConnection connection, IJournal journal, bool journalStarted = false)
   {
@@ -29,29 +30,48 @@ public sealed class XBaseTransaction : DbTransaction
   public override void Commit()
   {
     _journal.CommitAsync().GetAwaiter().GetResult();
+    _completed = true;
   }
 
   public override void Rollback()
   {
     _journal.RollbackAsync().GetAwaiter().GetResult();
+    _completed = true;
   }
 
   public override Task CommitAsync(CancellationToken cancellationToken = default)
   {
-    return _journal.CommitAsync(cancellationToken).AsTask();
+    return CommitInternalAsync(cancellationToken);
   }
 
   public override Task RollbackAsync(CancellationToken cancellationToken = default)
   {
-    return _journal.RollbackAsync(cancellationToken).AsTask();
+    return RollbackInternalAsync(cancellationToken);
   }
 
   protected override void Dispose(bool disposing)
   {
     if (!_disposed)
     {
+      if (disposing && !_completed)
+      {
+        _journal.RollbackAsync().GetAwaiter().GetResult();
+        _completed = true;
+      }
       _disposed = true;
       base.Dispose(disposing);
     }
+  }
+
+  private async Task CommitInternalAsync(CancellationToken cancellationToken)
+  {
+    await _journal.CommitAsync(cancellationToken).ConfigureAwait(false);
+    _completed = true;
+  }
+
+  private async Task RollbackInternalAsync(CancellationToken cancellationToken)
+  {
+    await _journal.RollbackAsync(cancellationToken).ConfigureAwait(false);
+    _completed = true;
   }
 }


### PR DESCRIPTION
## Summary
- track the completion state of `XBaseTransaction` operations and roll back the journal when disposing with outstanding work
- cover the disposal path with a regression test that asserts the journal rollback is triggered

## Testing
- dotnet test tests/XBase.Data.Tests/XBase.Data.Tests.csproj --configuration Release

------
https://chatgpt.com/codex/tasks/task_e_68dcde218490832284ed28ce5c5954c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Transactions now automatically roll back if disposed without an explicit commit.
  - Prevents duplicate commits/rollbacks by tracking transaction completion.
  - Aligns synchronous and asynchronous commit/rollback behavior for consistency and reliability.

- **Tests**
  - Added coverage to verify rollback occurs on dispose when not committed.
  - Enhanced test doubles to track and assert rollback invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->