### PR TITLE
docs: align M3 planning with online ddl focus

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,39 @@
+# xBase for .NET — Roadmap (ROADMAP.md)
+
+> **Release Horizon**: Phase A (M1–M6)
+> **Target Runtime**: .NET 8 LTS
+
+---
+
+## Milestone Overview
+
+| Milestone | Focus | Key Deliverables | Acceptance Signals |
+|-----------|-------|------------------|--------------------|
+| **M1 – Core Read** | Table metadata ingestion and read path bootstrap | DBF/DBT open/read, NTX/MDX navigation, `dbfinfo` tool | Fixtures load with correct schema + record counts |
+| **M2 – Core Write & Journal** | Durable write path with crash recovery | Insert/update/delete pipeline, WAL journal format, locking baseline | Crash simulations recover without data loss |
+| **M3 – Online DDL + ADO.NET** | In-Place Online DDL/IPOD plus provider surfacing | Schema-delta `.ddl` log, lazy backfill orchestration, provider DDL verbs, CLI `ddl apply/checkpoint/pack`, retained ADO.NET SELECT subset/parameters/transactions | Schema log replay tested, providers execute DDL end-to-end, tooling passes validation/dry-run scenarios |
+| **M4 – EF Core Read/Write** | LINQ translation and change tracking | EF Core provider, concurrency tokens, CRUD flows | CRUD round-trips with optimistic concurrency tests |
+| **M5 – Indexing & Tooling Enhancements** | Performance tuning and maintenance tooling | Predicate/order pushdown metrics, reindex/pack automation | Diagnostics show >70% index utilization, tooling scenarios green |
+| **M6 – Phase B Read** | FoxPro 2.x ingestion | DBF/FPT/CDX parsing, compatibility validation | FoxPro fixtures load with correct tag enumeration |
+
+---
+
+## Sequence & Dependencies
+
+1. **M1 → M2** lay the foundation for journal-aware mutation, a prerequisite for safe Online DDL replay.
+2. **M3** extends the mutation stack with schema-delta logging and provider/tooling integration so that ADO.NET clients can drive DDL without breaking online workloads.
+3. **M4** builds on M3 by reusing schema version metadata inside EF Core migrations, while M5 tunes performance and operational tooling ahead of the Phase A release.
+4. **M6** starts Phase B with FoxPro read support, leveraging the same IPOD pipeline where applicable.
+
+---
+
+## Status Tracking
+
+- **M1**: ✅ completed.
+- **M2**: ✅ completed.
+- **M3**: 🚧 in progress (Online DDL/IPOD + provider enablement).
+- **M4–M6**: ⏳ pending.
+
+---
+
+**End of ROADMAP.md**

--- a/requirements.md
+++ b/requirements.md
@@ -199,8 +199,10 @@ README.md
   *Acceptance*: open 20+ fixtures, correct schema and record counts.
 - **M2 (Core Write + Journal)**: I/U/D; journal commit/recover; basic locking.  
   *Acceptance*: crash simulation tests pass; no data loss.
-- **M3 (ADO.NET)**: SELECT subset; parameters; transactions.  
-  *Acceptance*: ADO.NET samples run cross‑platform; perf baselines met.
+- **M3 (Online DDL + ADO.NET)**: Deliver In-Place Online DDL/IPOD (schema-delta log, lazy backfill, DDL lock discipline) while
+  completing the ADO.NET surface (SELECT subset, parameters, transactions) needed to drive tooling and provider scenarios.
+  *Acceptance*: Schema-delta logging captured and replayed in tests; ADO.NET/EF providers issue DDL verbs end-to-end; CLI `ddl
+  apply/checkpoint/pack` commands ship with validation and dry-run coverage.
 - **M4 (EF Core Read/Write)**: LINQ subset; tracking; concurrency tokens.  
   *Acceptance*: CRUD round‑trips; concurrency tests pass.
 - **M5 (Indexes & Tools)**: Reindex/pack tools; predicate/order pushdown measured.  

--- a/tasks.md
+++ b/tasks.md
@@ -10,10 +10,11 @@
 - [x] Added `TableCatalog` directory discovery plus expression and diagnostics scaffolding (`ExpressionEvaluator`, `XBaseLogger`) covered by unit tests.
 - [x] Exercised loaders via fixture assertions in `XBase.Core.Tests` and smoke-tested the tooling pipeline through `XBase.Tools.Tests`.
 
-## M3 – Data Engine 🚧
-- [ ] Implement sequential/indexed cursor implementations that materialize records from DBF/DBT files.
-- [ ] Provide memo (DBT) block reader/writer with cache management and tests over fixtures.
-- [ ] Wire table mutators to support insert/update/delete against in-memory row buffers (beyond no-op stubs).
+## M3 – Online DDL & Provider Enablement 🚧
+- [ ] Implement schema-delta `.ddl` log with version tracking, lazy backfill queues, and recovery tests.
+- [ ] Extend core mutators and provider APIs to execute `CREATE/ALTER/DROP TABLE` plus index DDL with transactional guards.
+- [ ] Surface DDL verbs through the ADO.NET provider (command parser, execution pipeline, metadata exposure).
+- [ ] Ship CLI `xbase ddl apply/checkpoint/pack` commands with validation, dry-run, and integration tests.
 
 ## M4 – Journaling & Transactions ⏳
 - [x] Ensured `XBaseConnection` starts the journal for synchronous and asynchronous transactions with test coverage.


### PR DESCRIPTION
## Summary
- align the requirements milestone list to describe M3 as the Online DDL/IPOD plus ADO.NET deliverable with updated acceptance criteria
- refactor the M3 task tracker section around schema-delta logging, provider DDL enablement, and the ddl tooling surface
- add a roadmap summary that highlights the Online DDL emphasis for M3 and shows milestone sequencing/status

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dce1def8848322b1462c814fe22dfe