### PR TITLE
chore: remove unused using directive from XBaseCommand

### DIFF
--- a/src/XBase.Data/Providers/XBaseCommand.cs
+++ b/src/XBase.Data/Providers/XBaseCommand.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;


### PR DESCRIPTION
## Summary
- remove the unused System.Collections.Generic using from XBaseCommand

## Testing
- dotnet format xBase.sln --include src/XBase.Data/Providers/XBaseCommand.cs
- dotnet build xBase.sln -c Release

------
https://chatgpt.com/codex/tasks/task_e_68dce4e47da883229712241974e99586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed an unused reference to streamline the codebase and improve readability.
* **Chores**
  * Performed minor internal cleanup with no impact on app behavior or user experience.
  * No changes to features, settings, or public interfaces; functionality remains identical.
  * Low regression risk; no user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->