### PR TITLE
fix: allow DDL command tests to run against active build output

### DIFF
--- a/tests/XBase.Tools.Tests/DdlCommandTests.cs
+++ b/tests/XBase.Tools.Tests/DdlCommandTests.cs
@@ -14,7 +14,8 @@ public sealed class DdlCommandTests
   public async Task ApplyCommand_WritesSchemaLog()
   {
     string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
-    string toolAssembly = Path.Combine(repoRoot, "src", "XBase.Tools", "bin", "Release", "net8.0", "XBase.Tools.dll");
+    string buildConfiguration = GetBuildConfiguration();
+    string toolAssembly = Path.Combine(repoRoot, "src", "XBase.Tools", "bin", buildConfiguration, "net8.0", "XBase.Tools.dll");
     Assert.True(File.Exists(toolAssembly));
     string workspace = Path.Combine(Path.GetTempPath(), $"xbase-ddl-{Guid.NewGuid():N}");
     Directory.CreateDirectory(workspace);
@@ -73,7 +74,8 @@ public sealed class DdlCommandTests
   public async Task CheckpointDryRun_PrintsStatus()
   {
     string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
-    string toolAssembly = Path.Combine(repoRoot, "src", "XBase.Tools", "bin", "Release", "net8.0", "XBase.Tools.dll");
+    string buildConfiguration = GetBuildConfiguration();
+    string toolAssembly = Path.Combine(repoRoot, "src", "XBase.Tools", "bin", buildConfiguration, "net8.0", "XBase.Tools.dll");
     Assert.True(File.Exists(toolAssembly));
     string workspace = Path.Combine(Path.GetTempPath(), $"xbase-ddl-{Guid.NewGuid():N}");
     Directory.CreateDirectory(workspace);
@@ -124,7 +126,8 @@ public sealed class DdlCommandTests
   public async Task PackDryRun_PrintsStatus()
   {
     string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
-    string toolAssembly = Path.Combine(repoRoot, "src", "XBase.Tools", "bin", "Release", "net8.0", "XBase.Tools.dll");
+    string buildConfiguration = GetBuildConfiguration();
+    string toolAssembly = Path.Combine(repoRoot, "src", "XBase.Tools", "bin", buildConfiguration, "net8.0", "XBase.Tools.dll");
     Assert.True(File.Exists(toolAssembly));
     string workspace = Path.Combine(Path.GetTempPath(), $"xbase-ddl-{Guid.NewGuid():N}");
     Directory.CreateDirectory(workspace);
@@ -173,5 +176,18 @@ public sealed class DdlCommandTests
         Directory.Delete(workspace, recursive: true);
       }
     }
+  }
+
+  private static string GetBuildConfiguration()
+  {
+    var baseDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+    string? configuration = baseDirectory.Parent?.Name;
+
+    if (string.IsNullOrEmpty(configuration))
+    {
+      throw new InvalidOperationException("Unable to determine build configuration for test execution.");
+    }
+
+    return configuration;
   }
 }


### PR DESCRIPTION
## Summary
- derive the active build configuration from the test assembly location
- use the computed configuration when resolving the XBase.Tools binary for integration tests

## Testing
- dotnet test xBase.sln
- dotnet test xBase.sln --configuration Release

------
https://chatgpt.com/codex/tasks/task_e_68dd07826f2483229c03b4ca720822a2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by dynamically detecting the build configuration instead of using hardcoded paths.
  * Ensures tests run consistently across local and CI environments, reducing flakiness related to differing build outputs.
  * Enhances coverage of dry-run and schema logging scenarios by making path resolution resilient to configuration differences.
  * No changes to runtime behavior; end-user features remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->