### PR TITLE
Fix EF Core provider service wiring

### DIFF
--- a/src/XBase.EFCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/XBase.EFCore/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Update;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using XBase.Data.Providers;
+using XBase.EFCore.Internal;
+
+namespace XBase.EFCore.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+  public static IServiceCollection AddEntityFrameworkXBase(this IServiceCollection services)
+  {
+    var builder = new EntityFrameworkRelationalServicesBuilder(services);
+    builder.TryAddCoreServices();
+    builder
+      .TryAdd<IDatabaseProvider, XBaseDatabaseProvider>()
+      .TryAdd<LoggingDefinitions, XBaseLoggingDefinitions>()
+      .TryAdd<ISqlGenerationHelper, RelationalSqlGenerationHelper>()
+      .TryAdd<IRelationalTypeMappingSource, XBaseTypeMappingSource>()
+      .TryAdd<IQuerySqlGeneratorFactory, XBaseQuerySqlGeneratorFactory>()
+      .TryAdd<IModificationCommandBatchFactory, NoOpModificationCommandBatchFactory>();
+
+    services.TryAddScoped<IRelationalConnection>(provider =>
+    {
+      var options = provider.GetRequiredService<IDbContextOptions>();
+      var extension = options.FindExtension<XBaseOptionsExtension>();
+      var dependencies = provider.GetRequiredService<RelationalConnectionDependencies>();
+      XBaseConnection? connection = provider.GetService<XBaseConnection>();
+      return new XBaseRelationalConnection(dependencies, connection, extension?.ConnectionString);
+    });
+
+    return services;
+  }
+}

--- a/src/XBase.EFCore/Extensions/XBaseDbContextOptionsBuilderExtensions.cs
+++ b/src/XBase.EFCore/Extensions/XBaseDbContextOptionsBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
@@ -7,10 +8,33 @@ public static class XBaseDbContextOptionsBuilderExtensions
 {
   public static DbContextOptionsBuilder UseXBase(this DbContextOptionsBuilder builder, string connectionString)
   {
-    var infrastructure = (IDbContextOptionsBuilderInfrastructure)builder;
-    var extension = builder.Options.FindExtension<XBaseOptionsExtension>() ?? new XBaseOptionsExtension();
+    ArgumentNullException.ThrowIfNull(builder);
+    ArgumentNullException.ThrowIfNull(connectionString);
+
+    var extension = GetOrCreateExtension(builder);
     extension = extension.WithConnectionString(connectionString);
-    infrastructure.AddOrUpdateExtension(extension);
+    ((IDbContextOptionsBuilderInfrastructure)builder).AddOrUpdateExtension(extension);
+
+    var relationalExtension = GetOrCreateRelationalExtension(builder);
+    relationalExtension = relationalExtension.WithConnectionString(connectionString);
+    ((IDbContextOptionsBuilderInfrastructure)builder).AddOrUpdateExtension(relationalExtension);
     return builder;
+  }
+
+  public static DbContextOptionsBuilder<TContext> UseXBase<TContext>(this DbContextOptionsBuilder<TContext> builder, string connectionString)
+    where TContext : DbContext
+  {
+    UseXBase((DbContextOptionsBuilder)builder, connectionString);
+    return builder;
+  }
+
+  private static XBaseOptionsExtension GetOrCreateExtension(DbContextOptionsBuilder builder)
+  {
+    return builder.Options.FindExtension<XBaseOptionsExtension>() ?? new XBaseOptionsExtension();
+  }
+
+  private static XBaseRelationalOptionsExtension GetOrCreateRelationalExtension(DbContextOptionsBuilder builder)
+  {
+    return builder.Options.FindExtension<XBaseRelationalOptionsExtension>() ?? new XBaseRelationalOptionsExtension();
   }
 }

--- a/src/XBase.EFCore/Extensions/XBaseRelationalOptionsExtension.cs
+++ b/src/XBase.EFCore/Extensions/XBaseRelationalOptionsExtension.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace XBase.EFCore.Extensions;
+
+internal sealed class XBaseRelationalOptionsExtension : RelationalOptionsExtension
+{
+  private DbContextOptionsExtensionInfo? _info;
+
+  public XBaseRelationalOptionsExtension()
+  {
+  }
+
+  private XBaseRelationalOptionsExtension(XBaseRelationalOptionsExtension copy)
+    : base(copy)
+  {
+  }
+
+  protected override RelationalOptionsExtension Clone()
+  {
+    return new XBaseRelationalOptionsExtension(this);
+  }
+
+  public override DbContextOptionsExtensionInfo Info => _info ??= new ExtensionInfo(this);
+
+  public override void ApplyServices(IServiceCollection services)
+  {
+    services.AddEntityFrameworkXBase();
+  }
+
+  public new XBaseRelationalOptionsExtension WithConnectionString(string connectionString)
+  {
+    return (XBaseRelationalOptionsExtension)base.WithConnectionString(connectionString);
+  }
+
+  private sealed class ExtensionInfo : RelationalExtensionInfo
+  {
+    private readonly XBaseRelationalOptionsExtension _extension;
+
+    public ExtensionInfo(XBaseRelationalOptionsExtension extension)
+      : base(extension)
+    {
+      _extension = extension;
+    }
+
+    public override bool IsDatabaseProvider => true;
+
+    public override string LogFragment => "using XBase ";
+
+    public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+    {
+      debugInfo["XBase:ConnectionString"] = _extension.ConnectionString ?? string.Empty;
+    }
+  }
+}

--- a/src/XBase.EFCore/Internal/NoOpModificationCommandBatchFactory.cs
+++ b/src/XBase.EFCore/Internal/NoOpModificationCommandBatchFactory.cs
@@ -1,0 +1,12 @@
+using System;
+using Microsoft.EntityFrameworkCore.Update;
+
+namespace XBase.EFCore.Internal;
+
+internal sealed class NoOpModificationCommandBatchFactory : IModificationCommandBatchFactory
+{
+  public ModificationCommandBatch Create()
+  {
+    throw new NotSupportedException("Data modifications are not supported by the XBase provider.");
+  }
+}

--- a/src/XBase.EFCore/Internal/XBaseDatabaseProvider.cs
+++ b/src/XBase.EFCore/Internal/XBaseDatabaseProvider.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using XBase.EFCore.Extensions;
+
+namespace XBase.EFCore.Internal;
+
+public sealed class XBaseDatabaseProvider : IDatabaseProvider
+{
+  public string Name => "XBase";
+
+  public bool IsConfigured(IDbContextOptions options)
+  {
+    ArgumentNullException.ThrowIfNull(options);
+    return options.Extensions.OfType<XBaseOptionsExtension>().Any();
+  }
+}

--- a/src/XBase.EFCore/Internal/XBaseLoggingDefinitions.cs
+++ b/src/XBase.EFCore/Internal/XBaseLoggingDefinitions.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace XBase.EFCore.Internal;
+
+public sealed class XBaseLoggingDefinitions : RelationalLoggingDefinitions
+{
+}

--- a/src/XBase.EFCore/Internal/XBaseRelationalConnection.cs
+++ b/src/XBase.EFCore/Internal/XBaseRelationalConnection.cs
@@ -1,0 +1,39 @@
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Storage;
+using XBase.Data.Providers;
+
+namespace XBase.EFCore.Internal;
+
+internal sealed class XBaseRelationalConnection : RelationalConnection
+{
+  private readonly XBaseConnection? _providedConnection;
+  private readonly string? _connectionString;
+
+  public XBaseRelationalConnection(RelationalConnectionDependencies dependencies, XBaseConnection? connection, string? connectionString)
+    : base(dependencies)
+  {
+    _providedConnection = connection;
+    _connectionString = connectionString;
+  }
+
+  protected override DbConnection CreateDbConnection()
+  {
+    if (_providedConnection is not null)
+    {
+      if (!string.IsNullOrEmpty(_connectionString))
+      {
+        _providedConnection.ConnectionString = _connectionString;
+      }
+
+      return _providedConnection;
+    }
+
+    var connection = new XBaseConnection();
+    if (!string.IsNullOrEmpty(_connectionString))
+    {
+      connection.ConnectionString = _connectionString;
+    }
+
+    return connection;
+  }
+}

--- a/src/XBase.EFCore/Internal/XBaseTypeMappingSource.cs
+++ b/src/XBase.EFCore/Internal/XBaseTypeMappingSource.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace XBase.EFCore.Internal;
+
+internal sealed class XBaseTypeMappingSource : RelationalTypeMappingSource
+{
+  private static readonly RelationalTypeMapping IntegerMapping = new IntTypeMapping("INTEGER");
+  private static readonly RelationalTypeMapping StringMapping = new StringTypeMapping("TEXT", DbType.String, unicode: true, size: null);
+
+  private static readonly IReadOnlyDictionary<string, RelationalTypeMapping> StoreTypeMappings = new Dictionary<string, RelationalTypeMapping>(StringComparer.OrdinalIgnoreCase)
+  {
+    ["INTEGER"] = IntegerMapping,
+    ["INT"] = IntegerMapping,
+    ["CHAR"] = StringMapping,
+    ["TEXT"] = StringMapping
+  };
+
+  private static readonly IReadOnlyDictionary<Type, RelationalTypeMapping> ClrTypeMappings = new Dictionary<Type, RelationalTypeMapping>
+  {
+    [typeof(int)] = IntegerMapping,
+    [typeof(string)] = StringMapping
+  };
+
+  public XBaseTypeMappingSource(TypeMappingSourceDependencies dependencies, RelationalTypeMappingSourceDependencies relationalDependencies)
+    : base(dependencies, relationalDependencies)
+  {
+  }
+
+  protected override RelationalTypeMapping? FindMapping(in RelationalTypeMappingInfo mappingInfo)
+  {
+    if (mappingInfo.ClrType is Type clrType && ClrTypeMappings.TryGetValue(clrType, out var clrMapping))
+    {
+      return clrMapping;
+    }
+
+    if (!string.IsNullOrEmpty(mappingInfo.StoreTypeName) && StoreTypeMappings.TryGetValue(mappingInfo.StoreTypeName!, out var storeMapping))
+    {
+      return storeMapping;
+    }
+
+    if (mappingInfo.ClrType?.IsEnum == true)
+    {
+      return IntegerMapping;
+    }
+
+    return base.FindMapping(mappingInfo);
+  }
+}

--- a/tests/XBase.EFCore.Tests/UseXBaseTests.cs
+++ b/tests/XBase.EFCore.Tests/UseXBaseTests.cs
@@ -1,5 +1,19 @@
+using System.Buffers;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using XBase.Abstractions;
+using XBase.Core.Table;
+using XBase.Core.Transactions;
+using XBase.Data.Providers;
 using XBase.EFCore.Extensions;
+using XBase.EFCore.Internal;
 
 namespace XBase.EFCore.Tests;
 
@@ -18,7 +32,188 @@ public sealed class UseXBaseTests
     Assert.Equal("path=./data", extension!.ConnectionString);
   }
 
+  [Fact]
+  public void UseXBase_AllowsQueryExecution()
+  {
+    var descriptor = new TableDescriptor(
+      "Customers",
+      null,
+      new IFieldDescriptor[]
+      {
+        new FieldDescriptor("Id", "N", 4, 0, false),
+        new FieldDescriptor("Name", "C", 10, 0, true)
+      },
+      Array.Empty<IIndexDescriptor>(),
+      SchemaVersion.Start);
+
+    var resolver = new InMemoryTableResolver(descriptor);
+    var cursorFactory = new FakeCursorFactory(new()
+    {
+      ["Customers"] = new[]
+      {
+        CreateRecord(1, "Alice"),
+        CreateRecord(2, "Bob")
+      }
+    });
+
+    var connection = new XBaseConnection(cursorFactory, new NoOpJournal(), new NoOpSchemaMutator(), resolver);
+
+    var services = new ServiceCollection();
+    services.AddEntityFrameworkXBase();
+    services.AddScoped(_ => connection);
+
+    ServiceProvider provider = services.BuildServiceProvider();
+
+    var optionsBuilder = new DbContextOptionsBuilder<SampleContext>();
+    optionsBuilder.UseXBase("Data Source=memory");
+    optionsBuilder.UseInternalServiceProvider(provider);
+
+    using var context = new SampleContext(optionsBuilder.Options);
+    var relationalConnection = context.GetService<IRelationalConnection>();
+    relationalConnection.Open();
+
+    try
+    {
+      using var command = relationalConnection.DbConnection.CreateCommand();
+      command.CommandText = "SELECT Name FROM Customers WHERE Id = 2";
+
+      using var reader = command.ExecuteReader();
+      var names = new List<string?>();
+      while (reader.Read())
+      {
+        names.Add(reader.GetString(0));
+      }
+
+      Assert.Equal(new[] { "Bob" }, names);
+    }
+    finally
+    {
+      relationalConnection.Close();
+    }
+  }
+
+  private static ReadOnlySequence<byte> CreateRecord(int id, string name)
+  {
+    byte[] buffer = new byte[1 + 4 + 10];
+    buffer[0] = 0x20;
+    Encoding ascii = Encoding.ASCII;
+    ascii.GetBytes(id.ToString(CultureInfo.InvariantCulture).PadLeft(4, ' '), buffer.AsSpan(1, 4));
+    ascii.GetBytes(name.PadRight(10), buffer.AsSpan(5, 10));
+    return new ReadOnlySequence<byte>(buffer);
+  }
+
   private sealed class SampleContext : DbContext
   {
+    public SampleContext(DbContextOptions options)
+      : base(options)
+    {
+    }
+
+    public DbSet<Customer> Customers => Set<Customer>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+      var entity = modelBuilder.Entity<Customer>();
+      entity.ToTable("Customers");
+      entity.HasKey(customer => customer.Id);
+      entity.Property(customer => customer.Name).HasColumnName("Name");
+    }
+  }
+
+  private sealed class Customer
+  {
+    public int Id { get; set; }
+
+    public string? Name { get; set; }
+  }
+
+  private sealed class InMemoryTableResolver : ITableResolver
+  {
+    private readonly Dictionary<string, ITableDescriptor> _tables;
+
+    public InMemoryTableResolver(params ITableDescriptor[] tables)
+    {
+      _tables = tables.ToDictionary(table => table.Name, table => table, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public ValueTask<ITableDescriptor?> ResolveAsync(string tableName, CancellationToken cancellationToken = default)
+    {
+      _tables.TryGetValue(tableName, out ITableDescriptor? descriptor);
+      return ValueTask.FromResult<ITableDescriptor?>(descriptor);
+    }
+  }
+
+  private sealed class FakeCursorFactory : ICursorFactory
+  {
+    private readonly Dictionary<string, IReadOnlyList<ReadOnlySequence<byte>>> _records;
+
+    public FakeCursorFactory(Dictionary<string, IReadOnlyList<ReadOnlySequence<byte>>> records)
+    {
+      _records = records;
+    }
+
+    public ValueTask<ICursor> CreateSequentialAsync(ITableDescriptor table, CursorOptions options, CancellationToken cancellationToken = default)
+    {
+      IReadOnlyList<ReadOnlySequence<byte>> records = _records.TryGetValue(table.Name, out var value)
+        ? value
+        : Array.Empty<ReadOnlySequence<byte>>();
+
+      return ValueTask.FromResult<ICursor>(new FakeCursor(records));
+    }
+
+    public ValueTask<ICursor> CreateIndexedAsync(ITableDescriptor table, IIndexDescriptor index, CursorOptions options, CancellationToken cancellationToken = default)
+    {
+      return CreateSequentialAsync(table, options, cancellationToken);
+    }
+  }
+
+  private sealed class FakeCursor : ICursor
+  {
+    private readonly IReadOnlyList<ReadOnlySequence<byte>> _records;
+    private int _position = -1;
+
+    public FakeCursor(IReadOnlyList<ReadOnlySequence<byte>> records)
+    {
+      _records = records;
+    }
+
+    public ReadOnlySequence<byte> Current => _records[_position];
+
+    public ValueTask DisposeAsync()
+    {
+      return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<bool> ReadAsync(CancellationToken cancellationToken = default)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+      _position++;
+      return ValueTask.FromResult(_position < _records.Count);
+    }
+  }
+
+  private sealed class NoOpSchemaMutator : ISchemaMutator
+  {
+    public ValueTask<SchemaVersion> ExecuteAsync(
+      SchemaOperation operation,
+      string? author = null,
+      CancellationToken cancellationToken = default)
+    {
+      return ValueTask.FromResult(SchemaVersion.Start);
+    }
+
+    public ValueTask<IReadOnlyList<SchemaLogEntry>> ReadHistoryAsync(
+      string tableName,
+      CancellationToken cancellationToken = default)
+    {
+      return ValueTask.FromResult<IReadOnlyList<SchemaLogEntry>>(Array.Empty<SchemaLogEntry>());
+    }
+
+    public ValueTask<IReadOnlyList<SchemaBackfillTask>> ReadBackfillQueueAsync(
+      string tableName,
+      CancellationToken cancellationToken = default)
+    {
+      return ValueTask.FromResult<IReadOnlyList<SchemaBackfillTask>>(Array.Empty<SchemaBackfillTask>());
+    }
   }
 }


### PR DESCRIPTION
## Summary
- register the EF Core provider services with AddEntityFrameworkXBase and expose provider metadata
- add relational options extension and supporting infrastructure for connections, logging, and type mapping
- update the integration test to exercise the query pipeline through an EF Core context

## Testing
- dotnet test xBase.sln --no-build

------
https://chatgpt.com/codex/tasks/task_e_68dd0a1818648322ad16838f8d35f47c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced first-class EF Core integration for XBase, including a single DI registration entry point.
  - Added an easier configuration path on DbContext options (generic overload supported).
  - Implemented provider-specific relational connection handling and basic type mappings for common types.
- Behavior Changes
  - Data modifications are not supported and will now produce a clear error.
  - Provider is now recognized as a database provider in EF Core.
- Tests
  - Added an integration-style test confirming queries execute successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->