### PR TITLE
feat: integrate table resolver support

### DIFF
--- a/src/XBase.Abstractions/QueryContracts.cs
+++ b/src/XBase.Abstractions/QueryContracts.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace XBase.Abstractions;
+
+public interface ITableResolver
+{
+  ValueTask<TableResolveResult?> ResolveAsync(string commandText, CancellationToken cancellationToken = default);
+}
+
+public sealed record TableResolveResult
+{
+  public TableResolveResult(ITableDescriptor table, IReadOnlyList<TableColumn> columns, CursorOptions options)
+  {
+    Table = table ?? throw new ArgumentNullException(nameof(table));
+    Columns = columns ?? throw new ArgumentNullException(nameof(columns));
+    Options = options;
+  }
+
+  public ITableDescriptor Table { get; }
+
+  public IReadOnlyList<TableColumn> Columns { get; }
+
+  public CursorOptions Options { get; }
+}
+
+public sealed record TableColumn
+{
+  public TableColumn(string name, Type clrType, Func<ReadOnlySequence<byte>, object?> valueAccessor)
+  {
+    if (string.IsNullOrWhiteSpace(name))
+    {
+      throw new ArgumentException("Column name must be provided.", nameof(name));
+    }
+
+    Name = name;
+    ClrType = clrType ?? throw new ArgumentNullException(nameof(clrType));
+    ValueAccessor = valueAccessor ?? throw new ArgumentNullException(nameof(valueAccessor));
+  }
+
+  public string Name { get; }
+
+  public Type ClrType { get; }
+
+  public Func<ReadOnlySequence<byte>, object?> ValueAccessor { get; }
+}

--- a/src/XBase.Data/Providers/NoOpSchemaMutator.cs
+++ b/src/XBase.Data/Providers/NoOpSchemaMutator.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using XBase.Abstractions;
+
+namespace XBase.Data.Providers;
+
+public sealed class NoOpSchemaMutator : ISchemaMutator
+{
+  public ValueTask<SchemaVersion> ExecuteAsync(
+    SchemaOperation operation,
+    string? author = null,
+    CancellationToken cancellationToken = default)
+  {
+    if (operation is null)
+    {
+      throw new ArgumentNullException(nameof(operation));
+    }
+
+    cancellationToken.ThrowIfCancellationRequested();
+    return ValueTask.FromResult(SchemaVersion.Start);
+  }
+
+  public ValueTask<IReadOnlyList<SchemaLogEntry>> ReadHistoryAsync(
+    string tableName,
+    CancellationToken cancellationToken = default)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    IReadOnlyList<SchemaLogEntry> empty = Array.Empty<SchemaLogEntry>();
+    return ValueTask.FromResult(empty);
+  }
+
+  public ValueTask<IReadOnlyList<SchemaBackfillTask>> ReadBackfillQueueAsync(
+    string tableName,
+    CancellationToken cancellationToken = default)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    IReadOnlyList<SchemaBackfillTask> empty = Array.Empty<SchemaBackfillTask>();
+    return ValueTask.FromResult(empty);
+  }
+}

--- a/src/XBase.Data/Providers/NoOpTableResolver.cs
+++ b/src/XBase.Data/Providers/NoOpTableResolver.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+using System.Threading.Tasks;
+using XBase.Abstractions;
+
+namespace XBase.Data.Providers;
+
+public sealed class NoOpTableResolver : ITableResolver
+{
+  public ValueTask<TableResolveResult?> ResolveAsync(string commandText, CancellationToken cancellationToken = default)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    return ValueTask.FromResult<TableResolveResult?>(null);
+  }
+}

--- a/src/XBase.Data/Providers/XBaseDataReader.cs
+++ b/src/XBase.Data/Providers/XBaseDataReader.cs
@@ -1,42 +1,94 @@
 using System;
 using System.Buffers;
+using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
+using XBase.Abstractions;
 
 namespace XBase.Data.Providers;
 
 public sealed class XBaseDataReader : DbDataReader
 {
-  private readonly IReadOnlyList<ReadOnlySequence<byte>> _records;
-  private int _position = -1;
+  private readonly ICursor? _cursor;
+  private readonly IReadOnlyList<TableColumn> _columns;
+  private readonly Dictionary<string, int> _ordinals;
+  private readonly DbConnection? _connectionToClose;
+  private readonly bool _ownsCursor;
 
-  public XBaseDataReader(IReadOnlyList<ReadOnlySequence<byte>> records)
+  private bool _isClosed;
+  private bool _hasRowsInitialized;
+  private bool _hasRows;
+  private bool _hasPendingRecord;
+  private ReadOnlySequence<byte> _pendingRecord;
+  private ReadOnlySequence<byte> _currentRecord;
+  private bool _hasCurrent;
+
+  private XBaseDataReader(IReadOnlyList<TableColumn> columns, ICursor? cursor, bool ownsCursor, DbConnection? connectionToClose)
   {
-    _records = records;
+    _columns = columns ?? throw new ArgumentNullException(nameof(columns));
+    _cursor = cursor;
+    _ownsCursor = ownsCursor;
+    _connectionToClose = connectionToClose;
+    _ordinals = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+    for (int i = 0; i < _columns.Count; i++)
+    {
+      _ordinals[_columns[i].Name] = i;
+    }
   }
 
-  public override int FieldCount => 0;
+  public XBaseDataReader(ICursor cursor, IReadOnlyList<TableColumn> columns, DbConnection? connectionToClose = null)
+    : this(columns, cursor ?? throw new ArgumentNullException(nameof(cursor)), ownsCursor: true, connectionToClose)
+  {
+  }
 
-  public override bool HasRows => _records.Count > 0;
+  public static XBaseDataReader CreateEmpty()
+  {
+    return new XBaseDataReader(Array.Empty<TableColumn>(), cursor: null, ownsCursor: false, connectionToClose: null)
+    {
+      _hasRowsInitialized = true,
+      _hasRows = false
+    };
+  }
 
-  public override bool IsClosed => false;
+  public override int FieldCount => _columns.Count;
+
+  public override bool HasRows
+  {
+    get
+    {
+      EnsureNotClosed();
+      if (_cursor is null)
+      {
+        return false;
+      }
+
+      EnsureInitialized();
+      return _hasRows;
+    }
+  }
+
+  public override bool IsClosed => _isClosed;
 
   public override int RecordsAffected => 0;
 
   public override int Depth => 0;
 
+  public override object this[int ordinal] => GetValue(ordinal);
+
+  public override object this[string name] => GetValue(GetOrdinal(name));
+
   public override bool Read()
   {
-    _position++;
-    return _position < _records.Count;
+    return ReadInternalAsync(CancellationToken.None).GetAwaiter().GetResult();
   }
 
   public override Task<bool> ReadAsync(CancellationToken cancellationToken)
   {
     cancellationToken.ThrowIfCancellationRequested();
-    return Task.FromResult(Read());
+    return ReadInternalAsync(cancellationToken).AsTask();
   }
 
   public override bool NextResult()
@@ -50,79 +102,349 @@ public sealed class XBaseDataReader : DbDataReader
     return Task.FromResult(false);
   }
 
-  public override object GetValue(int ordinal)
-  {
-    throw new IndexOutOfRangeException();
-  }
-
-  public override bool IsDBNull(int ordinal)
-  {
-    return true;
-  }
-
-  public override int GetOrdinal(string name)
-  {
-    throw new IndexOutOfRangeException();
-  }
-
   public override string GetName(int ordinal)
   {
-    throw new IndexOutOfRangeException();
+    TableColumn column = GetColumn(ordinal);
+    return column.Name;
   }
 
   public override string GetDataTypeName(int ordinal)
   {
-    throw new IndexOutOfRangeException();
+    TableColumn column = GetColumn(ordinal);
+    return column.ClrType.Name;
   }
 
   public override Type GetFieldType(int ordinal)
   {
-    throw new IndexOutOfRangeException();
+    TableColumn column = GetColumn(ordinal);
+    return column.ClrType;
   }
 
-  public override object this[int ordinal] => GetValue(ordinal);
+  public override int GetOrdinal(string name)
+  {
+    if (!_ordinals.TryGetValue(name, out int ordinal))
+    {
+      throw new IndexOutOfRangeException($"Column '{name}' was not found.");
+    }
 
-  public override object this[string name] => GetValue(GetOrdinal(name));
+    return ordinal;
+  }
+
+  public override object GetValue(int ordinal)
+  {
+    object? value = GetRawValue(ordinal);
+    return value ?? DBNull.Value;
+  }
 
   public override int GetValues(object[] values)
   {
-    return 0;
+    if (values is null)
+    {
+      throw new ArgumentNullException(nameof(values));
+    }
+
+    int count = Math.Min(values.Length, FieldCount);
+    for (int i = 0; i < count; i++)
+    {
+      values[i] = GetValue(i);
+    }
+
+    return count;
   }
 
-  public override bool GetBoolean(int ordinal) => false;
+  public override bool IsDBNull(int ordinal)
+  {
+    return GetRawValue(ordinal) is null;
+  }
 
-  public override byte GetByte(int ordinal) => 0;
+  public override bool GetBoolean(int ordinal)
+  {
+    return Convert.ToBoolean(GetNonNullValue(ordinal), CultureInfo.InvariantCulture);
+  }
 
-  public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length) => 0;
+  public override byte GetByte(int ordinal)
+  {
+    return Convert.ToByte(GetNonNullValue(ordinal), CultureInfo.InvariantCulture);
+  }
 
-  public override char GetChar(int ordinal) => '\0';
+  public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length)
+  {
+    byte[] data = GetBuffer(ordinal);
+    return CopyBuffer(data, dataOffset, buffer, bufferOffset, length);
+  }
 
-  public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) => 0;
+  public override char GetChar(int ordinal)
+  {
+    return Convert.ToChar(GetNonNullValue(ordinal), CultureInfo.InvariantCulture);
+  }
 
-  public override Guid GetGuid(int ordinal) => Guid.Empty;
+  public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length)
+  {
+    char[] data = GetCharBuffer(ordinal);
+    if (buffer is null)
+    {
+      return data.Length;
+    }
 
-  public override short GetInt16(int ordinal) => 0;
+    int available = Math.Max(0, data.Length - (int)dataOffset);
+    int count = Math.Min(length, available);
+    if (count > 0)
+    {
+      Array.Copy(data, dataOffset, buffer, bufferOffset, count);
+    }
 
-  public override int GetInt32(int ordinal) => 0;
+    return count;
+  }
 
-  public override long GetInt64(int ordinal) => 0;
+  public override Guid GetGuid(int ordinal)
+  {
+    object value = GetNonNullValue(ordinal);
+    return value switch
+    {
+      Guid guid => guid,
+      string text => Guid.Parse(text),
+      byte[] bytes => new Guid(bytes),
+      ReadOnlyMemory<byte> memory => new Guid(memory.ToArray()),
+      _ => new Guid(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty)
+    };
+  }
 
-  public override float GetFloat(int ordinal) => 0f;
+  public override short GetInt16(int ordinal)
+  {
+    return Convert.ToInt16(GetNonNullValue(ordinal), CultureInfo.InvariantCulture);
+  }
 
-  public override double GetDouble(int ordinal) => 0d;
+  public override int GetInt32(int ordinal)
+  {
+    return Convert.ToInt32(GetNonNullValue(ordinal), CultureInfo.InvariantCulture);
+  }
 
-  public override string GetString(int ordinal) => string.Empty;
+  public override long GetInt64(int ordinal)
+  {
+    return Convert.ToInt64(GetNonNullValue(ordinal), CultureInfo.InvariantCulture);
+  }
 
-  public override decimal GetDecimal(int ordinal) => 0m;
+  public override float GetFloat(int ordinal)
+  {
+    return Convert.ToSingle(GetNonNullValue(ordinal), CultureInfo.InvariantCulture);
+  }
 
-  public override DateTime GetDateTime(int ordinal) => DateTime.MinValue;
+  public override double GetDouble(int ordinal)
+  {
+    return Convert.ToDouble(GetNonNullValue(ordinal), CultureInfo.InvariantCulture);
+  }
+
+  public override string GetString(int ordinal)
+  {
+    object? value = GetRawValue(ordinal);
+    return value switch
+    {
+      null => throw new InvalidOperationException("Value is null."),
+      string text => text,
+      ReadOnlyMemory<char> memory => new string(memory.Span),
+      ReadOnlyMemory<byte> bytes => System.Text.Encoding.UTF8.GetString(bytes.Span),
+      byte[] buffer => System.Text.Encoding.UTF8.GetString(buffer),
+      _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty
+    };
+  }
+
+  public override decimal GetDecimal(int ordinal)
+  {
+    return Convert.ToDecimal(GetNonNullValue(ordinal), CultureInfo.InvariantCulture);
+  }
+
+  public override DateTime GetDateTime(int ordinal)
+  {
+    return Convert.ToDateTime(GetNonNullValue(ordinal), CultureInfo.InvariantCulture);
+  }
 
   public override IEnumerator<object> GetEnumerator()
   {
-    yield break;
+    for (int i = 0; i < FieldCount; i++)
+    {
+      yield return GetValue(i);
+    }
   }
 
   public override void Close()
   {
+    Dispose(true);
+    GC.SuppressFinalize(this);
+  }
+
+  protected override void Dispose(bool disposing)
+  {
+    if (_isClosed)
+    {
+      return;
+    }
+
+    if (disposing)
+    {
+      if (_ownsCursor && _cursor is not null)
+      {
+        _cursor.DisposeAsync().AsTask().GetAwaiter().GetResult();
+      }
+
+      _connectionToClose?.Close();
+    }
+
+    _isClosed = true;
+  }
+
+  private void EnsureNotClosed()
+  {
+    if (_isClosed)
+    {
+      throw new InvalidOperationException("The data reader is closed.");
+    }
+  }
+
+  private void EnsureInitialized()
+  {
+    if (_hasRowsInitialized || _cursor is null)
+    {
+      _hasRowsInitialized = true;
+      return;
+    }
+
+    InitializeAsync(CancellationToken.None).GetAwaiter().GetResult();
+  }
+
+  private ValueTask EnsureInitializedAsync(CancellationToken cancellationToken)
+  {
+    if (_hasRowsInitialized || _cursor is null)
+    {
+      _hasRowsInitialized = true;
+      return ValueTask.CompletedTask;
+    }
+
+    return InitializeAsync(cancellationToken);
+  }
+
+  private async ValueTask InitializeAsync(CancellationToken cancellationToken)
+  {
+    bool has = await _cursor!.ReadAsync(cancellationToken).ConfigureAwait(false);
+    _hasRowsInitialized = true;
+    if (has)
+    {
+      _hasRows = true;
+      _pendingRecord = _cursor.Current;
+      _hasPendingRecord = true;
+    }
+    else
+    {
+      _hasRows = false;
+    }
+  }
+
+  private async ValueTask<bool> ReadInternalAsync(CancellationToken cancellationToken)
+  {
+    EnsureNotClosed();
+    await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+    if (_cursor is null)
+    {
+      _hasCurrent = false;
+      return false;
+    }
+
+    if (_hasPendingRecord)
+    {
+      _currentRecord = _pendingRecord;
+      _hasPendingRecord = false;
+      _hasCurrent = true;
+      return true;
+    }
+
+    bool has = await _cursor.ReadAsync(cancellationToken).ConfigureAwait(false);
+    if (!has)
+    {
+      _hasCurrent = false;
+      return false;
+    }
+
+    _currentRecord = _cursor.Current;
+    _hasCurrent = true;
+    return true;
+  }
+
+  private TableColumn GetColumn(int ordinal)
+  {
+    if ((uint)ordinal >= (uint)FieldCount)
+    {
+      throw new IndexOutOfRangeException();
+    }
+
+    return _columns[ordinal];
+  }
+
+  private object? GetRawValue(int ordinal)
+  {
+    EnsureNotClosed();
+    if (!_hasCurrent)
+    {
+      throw new InvalidOperationException("Read must be called before accessing data.");
+    }
+
+    TableColumn column = GetColumn(ordinal);
+    return column.ValueAccessor(_currentRecord);
+  }
+
+  private object GetNonNullValue(int ordinal)
+  {
+    object? value = GetRawValue(ordinal);
+    if (value is null)
+    {
+      throw new InvalidOperationException("Value is null.");
+    }
+
+    return value;
+  }
+
+  private byte[] GetBuffer(int ordinal)
+  {
+    object value = GetNonNullValue(ordinal);
+    return value switch
+    {
+      byte[] bytes => bytes,
+      ReadOnlyMemory<byte> memory => memory.ToArray(),
+      ReadOnlySequence<byte> sequence => sequence.ToArray(),
+      _ => throw new InvalidCastException($"Column '{GetName(ordinal)}' does not contain binary data.")
+    };
+  }
+
+  private char[] GetCharBuffer(int ordinal)
+  {
+    object value = GetNonNullValue(ordinal);
+    return value switch
+    {
+      string text => text.ToCharArray(),
+      char[] chars => chars,
+      ReadOnlyMemory<char> memory => memory.ToArray(),
+      _ => GetString(ordinal).ToCharArray()
+    };
+  }
+
+  private static long CopyBuffer(byte[] data, long dataOffset, byte[]? buffer, int bufferOffset, int length)
+  {
+    if (dataOffset < 0)
+    {
+      throw new ArgumentOutOfRangeException(nameof(dataOffset));
+    }
+
+    if (buffer is null)
+    {
+      return data.Length;
+    }
+
+    int available = Math.Max(0, data.Length - (int)dataOffset);
+    int count = Math.Min(length, available);
+    if (count > 0)
+    {
+      Array.Copy(data, dataOffset, buffer, bufferOffset, count);
+    }
+
+    return count;
   }
 }

--- a/src/XBase.EFCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/XBase.EFCore/Extensions/ServiceCollectionExtensions.cs
@@ -5,6 +5,9 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using XBase.Abstractions;
+using XBase.Core.Cursors;
+using XBase.Core.Transactions;
 using XBase.Data.Providers;
 using XBase.EFCore.Internal;
 
@@ -25,13 +28,29 @@ public static class ServiceCollectionExtensions
 
     services.Replace(ServiceDescriptor.Singleton<IQuerySqlGeneratorFactory, XBaseQuerySqlGeneratorFactory>());
 
+    services.TryAddSingleton<ICursorFactory, NoOpCursorFactory>();
+    services.TryAddSingleton<IJournal, NoOpJournal>();
+    services.TryAddSingleton<ISchemaMutator, NoOpSchemaMutator>();
+    services.TryAddSingleton<ITableResolver, NoOpTableResolver>();
+
     services.TryAddScoped<IRelationalConnection>(provider =>
     {
       var options = provider.GetRequiredService<IDbContextOptions>();
       var extension = options.FindExtension<XBaseOptionsExtension>();
       var dependencies = provider.GetRequiredService<RelationalConnectionDependencies>();
       XBaseConnection? connection = provider.GetService<XBaseConnection>();
-      return new XBaseRelationalConnection(dependencies, connection, extension?.ConnectionString);
+      var cursorFactory = provider.GetRequiredService<ICursorFactory>();
+      var journal = provider.GetRequiredService<IJournal>();
+      var schemaMutator = provider.GetRequiredService<ISchemaMutator>();
+      var tableResolver = provider.GetRequiredService<ITableResolver>();
+      return new XBaseRelationalConnection(
+        dependencies,
+        connection,
+        extension?.ConnectionString,
+        cursorFactory,
+        journal,
+        schemaMutator,
+        tableResolver);
     });
 
     return services;

--- a/src/XBase.EFCore/Extensions/XBaseOptionsExtension.cs
+++ b/src/XBase.EFCore/Extensions/XBaseOptionsExtension.cs
@@ -4,6 +4,9 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using XBase.Abstractions;
+using XBase.Core.Cursors;
+using XBase.Core.Transactions;
 using XBase.Data.Providers;
 using XBase.EFCore.Internal;
 
@@ -34,7 +37,18 @@ public sealed class XBaseOptionsExtension : IDbContextOptionsExtension
       var extension = options.FindExtension<XBaseOptionsExtension>();
       var dependencies = provider.GetRequiredService<RelationalConnectionDependencies>();
       XBaseConnection? connection = provider.GetService<XBaseConnection>();
-      return new XBaseRelationalConnection(dependencies, connection, extension?.ConnectionString);
+      var cursorFactory = provider.GetRequiredService<ICursorFactory>();
+      var journal = provider.GetRequiredService<IJournal>();
+      var schemaMutator = provider.GetRequiredService<ISchemaMutator>();
+      var tableResolver = provider.GetRequiredService<ITableResolver>();
+      return new XBaseRelationalConnection(
+        dependencies,
+        connection,
+        extension?.ConnectionString,
+        cursorFactory,
+        journal,
+        schemaMutator,
+        tableResolver);
     });
   }
 

--- a/src/XBase.EFCore/Internal/XBaseRelationalConnection.cs
+++ b/src/XBase.EFCore/Internal/XBaseRelationalConnection.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Data.Common;
 using Microsoft.EntityFrameworkCore.Storage;
+using XBase.Abstractions;
 using XBase.Data.Providers;
 
 namespace XBase.EFCore.Internal;
@@ -8,12 +10,27 @@ internal sealed class XBaseRelationalConnection : RelationalConnection
 {
   private readonly XBaseConnection? _providedConnection;
   private readonly string? _connectionString;
+  private readonly ICursorFactory _cursorFactory;
+  private readonly IJournal _journal;
+  private readonly ISchemaMutator _schemaMutator;
+  private readonly ITableResolver _tableResolver;
 
-  public XBaseRelationalConnection(RelationalConnectionDependencies dependencies, XBaseConnection? connection, string? connectionString)
+  public XBaseRelationalConnection(
+    RelationalConnectionDependencies dependencies,
+    XBaseConnection? connection,
+    string? connectionString,
+    ICursorFactory cursorFactory,
+    IJournal journal,
+    ISchemaMutator schemaMutator,
+    ITableResolver tableResolver)
     : base(dependencies)
   {
     _providedConnection = connection;
     _connectionString = connectionString;
+    _cursorFactory = cursorFactory ?? throw new ArgumentNullException(nameof(cursorFactory));
+    _journal = journal ?? throw new ArgumentNullException(nameof(journal));
+    _schemaMutator = schemaMutator ?? throw new ArgumentNullException(nameof(schemaMutator));
+    _tableResolver = tableResolver ?? throw new ArgumentNullException(nameof(tableResolver));
   }
 
   protected override DbConnection CreateDbConnection()
@@ -28,7 +45,7 @@ internal sealed class XBaseRelationalConnection : RelationalConnection
       return _providedConnection;
     }
 
-    var connection = new XBaseConnection();
+    var connection = new XBaseConnection(_cursorFactory, _journal, _schemaMutator, _tableResolver);
     if (!string.IsNullOrEmpty(_connectionString))
     {
       connection.ConnectionString = _connectionString;

--- a/tests/XBase.Data.Tests/XBaseCommandTests.cs
+++ b/tests/XBase.Data.Tests/XBaseCommandTests.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using XBase.Abstractions;
 using XBase.Core.Cursors;
+using XBase.Core.Table;
 using XBase.Data.Providers;
 using XBase.Core.Transactions;
 
@@ -47,6 +50,57 @@ public sealed class XBaseCommandTests
     Assert.Equal(SchemaOperationKind.DropTable, schemaMutator.Operations[0].Kind);
   }
 
+  [Fact]
+  public void ExecuteReader_WithResolver_ReturnsRows()
+  {
+    var records = new List<ReadOnlySequence<byte>>
+    {
+      CreateRecord(1, "Alice"),
+      CreateRecord(2, "Bob")
+    };
+
+    var cursorFactory = new StubCursorFactory(records);
+    var resolver = new StubTableResolver();
+    resolver.Register(
+      "SELECT * FROM Customers",
+      new TableResolveResult(
+        new TableDescriptor("Customers", null, Array.Empty<IFieldDescriptor>(), Array.Empty<IIndexDescriptor>(), SchemaVersion.Start),
+        new[]
+        {
+          new TableColumn("Id", typeof(int), sequence =>
+          {
+            byte[] data = sequence.ToArray();
+            return BitConverter.ToInt32(data, 0);
+          }),
+          new TableColumn("Name", typeof(string), sequence =>
+          {
+            byte[] data = sequence.ToArray();
+            return Encoding.UTF8.GetString(data, 4, data.Length - 4).TrimEnd('\0');
+          })
+        },
+        new CursorOptions(false, null, null)));
+
+    using var connection = new XBaseConnection(cursorFactory, new NoOpJournal(), new NoOpSchemaMutator(), resolver);
+    connection.Open();
+
+    using DbCommand command = connection.CreateCommand();
+    command.CommandText = "SELECT * FROM Customers";
+
+    using DbDataReader reader = command.ExecuteReader();
+
+    Assert.Equal(2, reader.FieldCount);
+    Assert.True(reader.HasRows);
+    Assert.Equal("Id", reader.GetName(0));
+    Assert.Equal(typeof(int), reader.GetFieldType(0));
+    Assert.True(reader.Read());
+    Assert.Equal(1, reader.GetInt32(0));
+    Assert.Equal("Alice", reader.GetString(1));
+    Assert.True(reader.Read());
+    Assert.Equal(2, reader.GetInt32(0));
+    Assert.Equal("Bob", reader.GetString(1));
+    Assert.False(reader.Read());
+  }
+
   private sealed class RecordingSchemaMutator : ISchemaMutator
   {
     private SchemaVersion _current = SchemaVersion.Start;
@@ -78,6 +132,89 @@ public sealed class XBaseCommandTests
       CancellationToken cancellationToken = default)
     {
       return ValueTask.FromResult<IReadOnlyList<SchemaBackfillTask>>(Array.Empty<SchemaBackfillTask>());
+    }
+  }
+
+  private static ReadOnlySequence<byte> CreateRecord(int id, string name)
+  {
+    byte[] buffer = new byte[4 + 16];
+    BitConverter.GetBytes(id).CopyTo(buffer, 0);
+    byte[] nameBytes = Encoding.UTF8.GetBytes(name);
+    Array.Copy(nameBytes, 0, buffer, 4, Math.Min(nameBytes.Length, 16));
+    return new ReadOnlySequence<byte>(buffer);
+  }
+
+  private sealed class StubCursorFactory : ICursorFactory
+  {
+    private readonly IReadOnlyList<ReadOnlySequence<byte>> _records;
+
+    public StubCursorFactory(IReadOnlyList<ReadOnlySequence<byte>> records)
+    {
+      _records = records;
+    }
+
+    public ValueTask<ICursor> CreateSequentialAsync(ITableDescriptor table, CursorOptions options, CancellationToken cancellationToken = default)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+      return ValueTask.FromResult<ICursor>(new StubCursor(_records));
+    }
+
+    public ValueTask<ICursor> CreateIndexedAsync(ITableDescriptor table, IIndexDescriptor index, CursorOptions options, CancellationToken cancellationToken = default)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+      return ValueTask.FromResult<ICursor>(new StubCursor(_records));
+    }
+  }
+
+  private sealed class StubCursor : ICursor
+  {
+    private readonly IReadOnlyList<ReadOnlySequence<byte>> _records;
+    private int _position = -1;
+
+    public StubCursor(IReadOnlyList<ReadOnlySequence<byte>> records)
+    {
+      _records = records;
+    }
+
+    public ReadOnlySequence<byte> Current { get; private set; }
+
+    public ValueTask DisposeAsync()
+    {
+      return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<bool> ReadAsync(CancellationToken cancellationToken = default)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+      _position++;
+      if (_position >= _records.Count)
+      {
+        return ValueTask.FromResult(false);
+      }
+
+      Current = _records[_position];
+      return ValueTask.FromResult(true);
+    }
+  }
+
+  private sealed class StubTableResolver : ITableResolver
+  {
+    private readonly Dictionary<string, TableResolveResult> _results = new(StringComparer.OrdinalIgnoreCase);
+
+    public void Register(string commandText, TableResolveResult result)
+    {
+      _results[commandText] = result;
+    }
+
+    public ValueTask<TableResolveResult?> ResolveAsync(string commandText, CancellationToken cancellationToken = default)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+      if (_results.TryGetValue(commandText, out TableResolveResult? result) && result is not null)
+      {
+        return ValueTask.FromResult<TableResolveResult?>(result);
+      }
+
+      return ValueTask.FromResult<TableResolveResult?>(default);
     }
   }
 }

--- a/tests/XBase.EFCore.Tests/UseXBaseTests.cs
+++ b/tests/XBase.EFCore.Tests/UseXBaseTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -32,12 +34,33 @@ public sealed class UseXBaseTests
   [Fact]
   public void UseXBase_AllowsQueryExecution()
   {
-    var cursorFactory = new FakeCursorFactory();
-    var connection = new XBaseConnection(cursorFactory, new NoOpJournal(), new NoOpSchemaMutator());
+    var records = new List<ReadOnlySequence<byte>>
+    {
+      CreateRecord(2, "Bob")
+    };
+
+    var cursorFactory = new FakeCursorFactory(records);
+    var resolver = new FakeTableResolver();
+    resolver.Register(
+      "SELECT Name FROM Customers WHERE Id = 2",
+      new TableResolveResult(
+        new TableDescriptor("Customers", null, Array.Empty<IFieldDescriptor>(), Array.Empty<IIndexDescriptor>(), SchemaVersion.Start),
+        new[]
+        {
+          new TableColumn("Name", typeof(string), sequence =>
+          {
+            byte[] data = sequence.ToArray();
+            return Encoding.UTF8.GetString(data, 4, data.Length - 4).TrimEnd('\0');
+          })
+        },
+        new CursorOptions(false, null, null)));
+
+    var connection = new XBaseConnection(cursorFactory, new NoOpJournal(), new NoOpSchemaMutator(), resolver);
 
     var services = new ServiceCollection();
     services.AddEntityFrameworkXBase();
     services.AddScoped(_ => connection);
+    services.AddScoped<ITableResolver>(_ => resolver);
 
     ServiceProvider provider = services.BuildServiceProvider();
 
@@ -56,7 +79,11 @@ public sealed class UseXBaseTests
 
       using var reader = command.ExecuteReader();
       Assert.NotNull(reader);
-      Assert.False(reader.HasRows);
+      Assert.True(reader.HasRows);
+      Assert.True(reader.Read());
+      Assert.Equal("Name", reader.GetName(0));
+      Assert.Equal("Bob", reader.GetString(0));
+      Assert.False(reader.Read());
     }
     finally
     {
@@ -89,24 +116,48 @@ public sealed class UseXBaseTests
     public string? Name { get; set; }
   }
 
+  private static ReadOnlySequence<byte> CreateRecord(int id, string name)
+  {
+    byte[] buffer = new byte[4 + 16];
+    BitConverter.GetBytes(id).CopyTo(buffer, 0);
+    byte[] nameBytes = Encoding.UTF8.GetBytes(name);
+    Array.Copy(nameBytes, 0, buffer, 4, Math.Min(nameBytes.Length, 16));
+    return new ReadOnlySequence<byte>(buffer);
+  }
+
   private sealed class FakeCursorFactory : ICursorFactory
   {
+    private readonly IReadOnlyList<ReadOnlySequence<byte>> _records;
+
+    public FakeCursorFactory(IReadOnlyList<ReadOnlySequence<byte>> records)
+    {
+      _records = records;
+    }
+
     public ValueTask<ICursor> CreateSequentialAsync(ITableDescriptor table, CursorOptions options, CancellationToken cancellationToken = default)
     {
       cancellationToken.ThrowIfCancellationRequested();
-      return ValueTask.FromResult<ICursor>(new FakeCursor());
+      return ValueTask.FromResult<ICursor>(new FakeCursor(_records));
     }
 
     public ValueTask<ICursor> CreateIndexedAsync(ITableDescriptor table, IIndexDescriptor index, CursorOptions options, CancellationToken cancellationToken = default)
     {
       cancellationToken.ThrowIfCancellationRequested();
-      return ValueTask.FromResult<ICursor>(new FakeCursor());
+      return ValueTask.FromResult<ICursor>(new FakeCursor(_records));
     }
   }
 
   private sealed class FakeCursor : ICursor
   {
-    public ReadOnlySequence<byte> Current => ReadOnlySequence<byte>.Empty;
+    private readonly IReadOnlyList<ReadOnlySequence<byte>> _records;
+    private int _position = -1;
+
+    public FakeCursor(IReadOnlyList<ReadOnlySequence<byte>> records)
+    {
+      _records = records;
+    }
+
+    public ReadOnlySequence<byte> Current { get; private set; }
 
     public ValueTask DisposeAsync()
     {
@@ -116,32 +167,35 @@ public sealed class UseXBaseTests
     public ValueTask<bool> ReadAsync(CancellationToken cancellationToken = default)
     {
       cancellationToken.ThrowIfCancellationRequested();
-      return ValueTask.FromResult(false);
+      _position++;
+      if (_position >= _records.Count)
+      {
+        return ValueTask.FromResult(false);
+      }
+
+      Current = _records[_position];
+      return ValueTask.FromResult(true);
     }
   }
 
-  private sealed class NoOpSchemaMutator : ISchemaMutator
+  private sealed class FakeTableResolver : ITableResolver
   {
-    public ValueTask<SchemaVersion> ExecuteAsync(
-      SchemaOperation operation,
-      string? author = null,
-      CancellationToken cancellationToken = default)
+    private readonly Dictionary<string, TableResolveResult> _results = new(StringComparer.OrdinalIgnoreCase);
+
+    public void Register(string commandText, TableResolveResult result)
     {
-      return ValueTask.FromResult(SchemaVersion.Start);
+      _results[commandText] = result;
     }
 
-    public ValueTask<IReadOnlyList<SchemaLogEntry>> ReadHistoryAsync(
-      string tableName,
-      CancellationToken cancellationToken = default)
+    public ValueTask<TableResolveResult?> ResolveAsync(string commandText, CancellationToken cancellationToken = default)
     {
-      return ValueTask.FromResult<IReadOnlyList<SchemaLogEntry>>(Array.Empty<SchemaLogEntry>());
-    }
+      cancellationToken.ThrowIfCancellationRequested();
+      if (_results.TryGetValue(commandText, out TableResolveResult? result) && result is not null)
+      {
+        return ValueTask.FromResult<TableResolveResult?>(result);
+      }
 
-    public ValueTask<IReadOnlyList<SchemaBackfillTask>> ReadBackfillQueueAsync(
-      string tableName,
-      CancellationToken cancellationToken = default)
-    {
-      return ValueTask.FromResult<IReadOnlyList<SchemaBackfillTask>>(Array.Empty<SchemaBackfillTask>());
+      return ValueTask.FromResult<TableResolveResult?>(default);
     }
   }
 }


### PR DESCRIPTION
## Summary
- introduce an ITableResolver contract with default no-op implementations
- update XBaseConnection, command execution, and data reader to stream records resolved via the new abstraction
- register the resolver in the EF Core pipeline and add provider/EF tests covering row materialization

## Testing
- dotnet format whitespace --no-restore --verbosity diagnostic
- dotnet test xBase.sln --configuration Release

------
https://chatgpt.com/codex/tasks/task_e_68dd20c683ac8322948182860a916342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Pluggable table resolution for commands.
  - Schema-aware data reader with rich type accessors and ordinal/name lookups.
  - Improved async and cancellation handling across command execution.
  - Dependency injection now registers default provider/resolver services.

- Refactor
  - Command and connection flow updated to use resolver-driven table discovery.
  - Centralized reader execution path; EF Core integration extended accordingly.

- Tests
  - Added tests validating resolver-based queries and row materialization.

- Chores
  - Introduced no-op implementations for schema mutation and table resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->