### PR TITLE
feat: implement pack/reindex maintenance flows

### DIFF
--- a/src/XBase.Abstractions/StorageContracts.cs
+++ b/src/XBase.Abstractions/StorageContracts.cs
@@ -36,7 +36,8 @@ public enum SchemaOperationKind
   CreateIndex,
   DropIndex,
   Checkpoint,
-  Pack
+  Pack,
+  Reindex
 }
 
 public sealed record SchemaOperation
@@ -374,6 +375,14 @@ public interface ISchemaMutator
     CancellationToken cancellationToken = default);
 
   ValueTask<IReadOnlyList<SchemaBackfillTask>> ReadBackfillQueueAsync(
+    string tableName,
+    CancellationToken cancellationToken = default);
+
+  ValueTask<int> PackAsync(
+    string tableName,
+    CancellationToken cancellationToken = default);
+
+  ValueTask<int> ReindexAsync(
     string tableName,
     CancellationToken cancellationToken = default);
 }

--- a/src/XBase.Data/Providers/NoOpSchemaMutator.cs
+++ b/src/XBase.Data/Providers/NoOpSchemaMutator.cs
@@ -39,4 +39,16 @@ public sealed class NoOpSchemaMutator : ISchemaMutator
     IReadOnlyList<SchemaBackfillTask> empty = Array.Empty<SchemaBackfillTask>();
     return ValueTask.FromResult(empty);
   }
+
+  public ValueTask<int> PackAsync(string tableName, CancellationToken cancellationToken = default)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    return ValueTask.FromResult(0);
+  }
+
+  public ValueTask<int> ReindexAsync(string tableName, CancellationToken cancellationToken = default)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    return ValueTask.FromResult(0);
+  }
 }

--- a/tests/TestSupport/DbfTestBuilder.cs
+++ b/tests/TestSupport/DbfTestBuilder.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace XBase.TestSupport;
+
+public static class DbfTestBuilder
+{
+  public static string CreateTable(string directory, string tableName, params (bool deleted, string code)[] records)
+  {
+    if (string.IsNullOrWhiteSpace(directory))
+    {
+      throw new ArgumentException("Directory must be provided.", nameof(directory));
+    }
+
+    if (string.IsNullOrWhiteSpace(tableName))
+    {
+      throw new ArgumentException("Table name must be provided.", nameof(tableName));
+    }
+
+    Directory.CreateDirectory(directory);
+    string path = Path.Combine(directory, tableName + ".dbf");
+    WriteDbf(path, records);
+    return path;
+  }
+
+  public static string CreateIndex(string directory, string fileName, string contents)
+  {
+    if (string.IsNullOrWhiteSpace(directory))
+    {
+      throw new ArgumentException("Directory must be provided.", nameof(directory));
+    }
+
+    if (string.IsNullOrWhiteSpace(fileName))
+    {
+      throw new ArgumentException("File name must be provided.", nameof(fileName));
+    }
+
+    Directory.CreateDirectory(directory);
+    string path = Path.Combine(directory, fileName);
+    File.WriteAllText(path, contents ?? string.Empty, Encoding.UTF8);
+    return path;
+  }
+
+  private static void WriteDbf(string path, IReadOnlyList<(bool deleted, string code)> records)
+  {
+    byte version = 0x03;
+    DateTime now = DateTime.UtcNow;
+    ushort recordLength = 5; // delete flag + 4 byte CODE field
+    ushort headerLength = 32 + 32 + 1;
+    uint recordCount = records is null ? 0u : (uint)records.Count;
+
+    byte[] header = new byte[headerLength];
+    header[0] = version;
+    header[1] = (byte)Math.Clamp(now.Year - 1900, 0, 255);
+    header[2] = (byte)now.Month;
+    header[3] = (byte)now.Day;
+    BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(4, 4), recordCount);
+    BinaryPrimitives.WriteUInt16LittleEndian(header.AsSpan(8, 2), headerLength);
+    BinaryPrimitives.WriteUInt16LittleEndian(header.AsSpan(10, 2), recordLength);
+    header[29] = 0x00;
+
+    Span<byte> descriptor = header.AsSpan(32, 32);
+    Encoding ascii = Encoding.ASCII;
+    ascii.GetBytes("CODE".PadRight(11, '\0'), descriptor[..11]);
+    descriptor[11] = (byte)'C';
+    descriptor[16] = 4;
+    descriptor[17] = 0;
+    descriptor[18] = 0;
+    header[64] = 0x0D;
+
+    string? directory = Path.GetDirectoryName(path);
+    if (!string.IsNullOrEmpty(directory))
+    {
+      Directory.CreateDirectory(directory);
+    }
+
+    using FileStream stream = new(path, FileMode.Create, FileAccess.Write, FileShare.None);
+    stream.Write(header);
+
+    if (records is not null)
+    {
+      foreach ((bool deleted, string code) in records)
+      {
+        byte[] buffer = new byte[recordLength];
+        buffer[0] = deleted ? (byte)'*' : (byte)' ';
+        string normalized = (code ?? string.Empty).PadRight(4);
+        ascii.GetBytes(normalized.AsSpan(0, 4), buffer.AsSpan(1));
+        stream.Write(buffer);
+      }
+    }
+
+    stream.WriteByte(0x1A);
+    stream.Flush(true);
+  }
+}

--- a/tests/XBase.Core.Tests/SchemaLogTests.cs
+++ b/tests/XBase.Core.Tests/SchemaLogTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using XBase.Abstractions;
 using XBase.Core.Ddl;
+using XBase.TestSupport;
 
 namespace XBase.Core.Tests;
 
@@ -74,6 +75,7 @@ public sealed class SchemaLogTests
   {
     using var workspace = new TemporaryWorkspace();
     var mutator = new SchemaMutator(workspace.DirectoryPath);
+    DbfTestBuilder.CreateTable(workspace.DirectoryPath, "customers", (false, "A001"));
 
     var addColumn = new SchemaOperation(
       SchemaOperationKind.AlterTableAddColumn,
@@ -102,6 +104,7 @@ public sealed class SchemaLogTests
   {
     using var workspace = new TemporaryWorkspace();
     var mutator = new SchemaMutator(workspace.DirectoryPath);
+    DbfTestBuilder.CreateTable(workspace.DirectoryPath, "customers", (false, "A001"));
 
     var addColumn = new SchemaOperation(
       SchemaOperationKind.AlterTableAddColumn,
@@ -121,6 +124,7 @@ public sealed class SchemaLogTests
     Assert.Equal(version, queue[0].Version);
 
     var freshMutator = new SchemaMutator(workspace.DirectoryPath);
+    DbfTestBuilder.CreateTable(workspace.DirectoryPath, "customers", (false, "A001"));
     IReadOnlyList<SchemaBackfillTask> persisted = await freshMutator.ReadBackfillQueueAsync("customers").ConfigureAwait(false);
     Assert.Single(persisted);
 

--- a/tests/XBase.Core.Tests/SchemaMutatorIntegrationTests.cs
+++ b/tests/XBase.Core.Tests/SchemaMutatorIntegrationTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using XBase.Abstractions;
+using XBase.Core.Ddl;
+using XBase.Core.Table;
+using XBase.TestSupport;
+
+namespace XBase.Core.Tests;
+
+public sealed class SchemaMutatorIntegrationTests
+{
+  [Fact]
+  public async Task PackAsync_WithDeletedRecords_RebuildsDataAndIndexes()
+  {
+    using var workspace = new TemporaryWorkspace();
+    string tableName = "customers";
+    string dbfPath = DbfTestBuilder.CreateTable(
+      workspace.DirectoryPath,
+      tableName,
+      (false, "A001"),
+      (true, "A002"),
+      (false, "A003"));
+    string indexPath = DbfTestBuilder.CreateIndex(workspace.DirectoryPath, tableName + ".ntx", "legacy-index");
+    var mutator = new SchemaMutator(workspace.DirectoryPath);
+
+    var addColumn = new SchemaOperation(
+      SchemaOperationKind.AlterTableAddColumn,
+      tableName,
+      "balance",
+      new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["column"] = "balance",
+        ["definition"] = "N(10,2)"
+      });
+    await mutator.ExecuteAsync(addColumn, "tester").ConfigureAwait(false);
+
+    int removed = await mutator.PackAsync(tableName).ConfigureAwait(false);
+    Assert.Equal(1, removed);
+
+    var loader = new DbfTableLoader();
+    DbfTableDescriptor descriptor = loader.LoadDbf(dbfPath);
+    Assert.Equal<uint>(2u, descriptor.RecordCount);
+
+    using (FileStream stream = new(dbfPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+    {
+      stream.Seek(descriptor.HeaderLength, SeekOrigin.Begin);
+      byte[] record = new byte[descriptor.RecordLength];
+
+      int read = stream.Read(record, 0, record.Length);
+      Assert.Equal(record.Length, read);
+      Assert.Equal((byte)' ', record[0]);
+      Assert.Equal("A001", System.Text.Encoding.ASCII.GetString(record, 1, 4));
+
+      read = stream.Read(record, 0, record.Length);
+      Assert.Equal(record.Length, read);
+      Assert.Equal((byte)' ', record[0]);
+      Assert.Equal("A003", System.Text.Encoding.ASCII.GetString(record, 1, 4));
+
+      int terminator = stream.ReadByte();
+      Assert.Equal(0x1A, terminator);
+    }
+
+    string manifest = File.ReadAllText(indexPath);
+    Assert.Contains("xBase Index Manifest", manifest);
+    Assert.Contains("RecordCount: 2", manifest);
+    Assert.Contains("Fields: CODE", manifest);
+
+    IReadOnlyList<SchemaBackfillTask> queue = await mutator.ReadBackfillQueueAsync(tableName).ConfigureAwait(false);
+    Assert.Empty(queue);
+  }
+
+  [Fact]
+  public async Task ReindexAsync_WithStaleIndex_RewritesManifest()
+  {
+    using var workspace = new TemporaryWorkspace();
+    string tableName = "orders";
+    string dbfPath = DbfTestBuilder.CreateTable(
+      workspace.DirectoryPath,
+      tableName,
+      (false, "B001"),
+      (false, "B002"));
+    string indexPath = DbfTestBuilder.CreateIndex(workspace.DirectoryPath, tableName + ".ntx", "stale");
+    var mutator = new SchemaMutator(workspace.DirectoryPath);
+
+    int rebuilt = await mutator.ReindexAsync(tableName).ConfigureAwait(false);
+    Assert.Equal(1, rebuilt);
+
+    string manifest = File.ReadAllText(indexPath);
+    Assert.Contains("xBase Index Manifest", manifest);
+    Assert.Contains("RecordCount: 2", manifest);
+    Assert.Contains($"Table: {tableName}", manifest);
+
+    IReadOnlyList<SchemaBackfillTask> queue = await mutator.ReadBackfillQueueAsync(tableName).ConfigureAwait(false);
+    Assert.Empty(queue);
+
+    var loader = new DbfTableLoader();
+    DbfTableDescriptor descriptor = loader.LoadDbf(dbfPath);
+    Assert.Equal<uint>(2u, descriptor.RecordCount);
+  }
+}

--- a/tests/XBase.Core.Tests/XBase.Core.Tests.csproj
+++ b/tests/XBase.Core.Tests/XBase.Core.Tests.csproj
@@ -26,4 +26,8 @@
     <ProjectReference Include="..\..\src\XBase.Core\XBase.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\TestSupport\DbfTestBuilder.cs" Link="DbfTestBuilder.cs" />
+  </ItemGroup>
+
 </Project>

--- a/tests/XBase.Data.Tests/XBaseCommandTests.cs
+++ b/tests/XBase.Data.Tests/XBaseCommandTests.cs
@@ -133,6 +133,16 @@ public sealed class XBaseCommandTests
     {
       return ValueTask.FromResult<IReadOnlyList<SchemaBackfillTask>>(Array.Empty<SchemaBackfillTask>());
     }
+
+    public ValueTask<int> PackAsync(string tableName, CancellationToken cancellationToken = default)
+    {
+      return ValueTask.FromResult(0);
+    }
+
+    public ValueTask<int> ReindexAsync(string tableName, CancellationToken cancellationToken = default)
+    {
+      return ValueTask.FromResult(0);
+    }
   }
 
   private static ReadOnlySequence<byte> CreateRecord(int id, string name)

--- a/tests/XBase.Data.Tests/XBaseConnectionTests.cs
+++ b/tests/XBase.Data.Tests/XBaseConnectionTests.cs
@@ -112,5 +112,15 @@ public sealed class XBaseConnectionTests
     {
       return ValueTask.FromResult<IReadOnlyList<SchemaBackfillTask>>(Array.Empty<SchemaBackfillTask>());
     }
+
+    public ValueTask<int> PackAsync(string tableName, CancellationToken cancellationToken = default)
+    {
+      return ValueTask.FromResult(0);
+    }
+
+    public ValueTask<int> ReindexAsync(string tableName, CancellationToken cancellationToken = default)
+    {
+      return ValueTask.FromResult(0);
+    }
   }
 }

--- a/tests/XBase.Tools.Tests/XBase.Tools.Tests.csproj
+++ b/tests/XBase.Tools.Tests/XBase.Tools.Tests.csproj
@@ -27,4 +27,8 @@
     <ProjectReference Include="..\..\src\XBase.Core\XBase.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\TestSupport\DbfTestBuilder.cs" Link="DbfTestBuilder.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- implement asynchronous pack and reindex APIs that compact DBF data and rebuild sidecar indexes
- update schema command parsing/execution and CLI tooling to surface PACK/REINDEX verbs
- add shared DBF fixture builder plus integration tests that verify compaction clears queues and regenerates indexes

## Testing
- dotnet test xBase.sln --configuration Release --no-build
- dotnet test tests/XBase.Core.Tests/XBase.Core.Tests.csproj --configuration Release --no-build

------
https://chatgpt.com/codex/tasks/task_e_68dd28aa1c58832284b8d63406f151d4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added table Pack and Reindex operations, returning affected counts in command execution.
  - CLI: new ddl reindex and dbfreindex commands with optional --dry-run summaries.
  - Packing now also rebuilds indexes to keep data and indexes in sync.
  - Improved validation and error handling for missing or invalid tables.

- Tests
  - Added integration and end-to-end tests covering Pack and Reindex flows.
  - Introduced test utilities for creating DBF tables and index files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->