### PR TITLE
feat: defer index rebuilds via backfill queue

### DIFF
--- a/src/XBase.Core/Ddl/SchemaBackfillQueue.cs
+++ b/src/XBase.Core/Ddl/SchemaBackfillQueue.cs
@@ -58,6 +58,28 @@ public sealed class SchemaBackfillQueue
     return ValueTask.CompletedTask;
   }
 
+  public ValueTask RemoveAsync(Func<SchemaBackfillTask, bool> predicate, CancellationToken cancellationToken = default)
+  {
+    if (predicate is null)
+    {
+      throw new ArgumentNullException(nameof(predicate));
+    }
+
+    List<SchemaBackfillTask> buffer = new(ReadInternal());
+    if (buffer.Count == 0)
+    {
+      return ValueTask.CompletedTask;
+    }
+
+    int removed = buffer.RemoveAll(task => predicate(task));
+    if (removed > 0)
+    {
+      WriteInternal(buffer);
+    }
+
+    return ValueTask.CompletedTask;
+  }
+
   private IReadOnlyList<SchemaBackfillTask> ReadInternal()
   {
     if (!File.Exists(_filePath))

--- a/tasks.md
+++ b/tasks.md
@@ -20,7 +20,7 @@
 - [x] Ensured `XBaseConnection` starts the journal for synchronous and asynchronous transactions with test coverage.
 - [x] Design and implement the WAL journal format covering FR-WT-1 – FR-WT-4 requirements with crash-recovery tests.
 - [x] Introduce lock coordination (file + optional record locks) and acceptance tests simulating concurrent access.
-- [ ] Implement deferred index maintenance hooks to enable safe reindex/pack flows.
+- [x] Implement deferred index maintenance hooks to enable safe reindex/pack flows.
 
 ## M5 – Provider Integrations ⏳
 - [ ] Complete ADO.NET command execution pipeline (parser, plan builder, `XBaseDataReader`) returning real records.

--- a/tests/XBase.Tools.Tests/DdlCommandTests.cs
+++ b/tests/XBase.Tools.Tests/DdlCommandTests.cs
@@ -200,16 +200,16 @@ public sealed class DdlCommandTests
         (false, "A003"));
       string indexPath = DbfTestBuilder.CreateIndex(workspacePath, tableName + ".ntx", "legacy");
       var mutator = new SchemaMutator(workspacePath);
-    var addColumn = new SchemaOperation(
-      SchemaOperationKind.AlterTableAddColumn,
-      tableName,
-      "balance",
-      new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-      {
-        ["column"] = "balance",
-        ["definition"] = "N(10,2)"
-      });
-    await mutator.ExecuteAsync(addColumn, "cli").ConfigureAwait(false);
+      var addColumn = new SchemaOperation(
+        SchemaOperationKind.AlterTableAddColumn,
+        tableName,
+        "balance",
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["column"] = "balance",
+          ["definition"] = "N(10,2)"
+        });
+      await mutator.ExecuteAsync(addColumn, "cli").ConfigureAwait(false);
 
       using var process = new Process
       {


### PR DESCRIPTION
## Summary
- queue pack/reindex index rebuilds through schema backfill metadata so maintenance resumes after crashes
- add selective backfill task removal helpers and coverage for deferred reindex recovery
- mark the deferred index maintenance milestone complete in the task tracker

## Testing
- dotnet test xBase.sln --configuration Release

------
https://chatgpt.com/codex/tasks/task_e_68dd41909858832283706a09070dab09

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced deferred, queue-based index maintenance for Pack/Reindex, enabling safer, resumable rewrites with atomic file replacement.
  - Added capability to clean up pending maintenance tasks to keep queues current.
- Refactor
  - Unified Pack/Reindex flows to route index updates through a scheduled processing pipeline.
- Tests
  - Added integration coverage to ensure queued maintenance completes during reindex and preserves expected record counts.
- Chores
  - Updated project tasks to mark deferred index maintenance as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->