### PR TITLE
docs: update M5 provider milestones

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -23,8 +23,8 @@
 - [x] Implement deferred index maintenance hooks to enable safe reindex/pack flows.
 
 ## M5 – Provider Integrations ⏳
-- [ ] Complete ADO.NET command execution pipeline (parser, plan builder, `XBaseDataReader`) returning real records.
-- [ ] Implement EF Core provider services (type mappings, query translation, change tracking) backed by integration tests.
+- [x] Complete ADO.NET command execution pipeline (parser, plan builder, `XBaseDataReader`) returning real records.
+- [x] Implement EF Core provider services (type mappings, query translation, change tracking) backed by integration tests.
 - [ ] Deliver connection string/journaling options surface plus configuration docs.
 
 ## M6 – Tooling, Docs & Release ⏳


### PR DESCRIPTION
## Summary
- mark the M5 ADO.NET and EF Core provider items as complete after verifying the implemented pipelines

## Testing
- `dotnet test xBase.sln --configuration Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68dd4416ed2483228bead20ed1507748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled real query results through the ADO.NET command execution pipeline.
  * Added EF Core provider capabilities, including query translation, type mapping, and change tracking.

* **Tests**
  * Added integration tests to validate provider behavior and end-to-end scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->