### PR TITLE
feat(data): add connection string and journaling configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ Individual steps can be executed with the corresponding command (e.g., `verify`,
 
 - [requirements.md](requirements.md)
 - [architecture.md](architecture.md)
+- [docs/configuration.md](docs/configuration.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,56 @@
+# Configuration Guide
+
+This document describes how to configure xBase .NET connections, including the connection string format and journaling controls exposed by the provider surface.
+
+## Connection String Format
+
+xBase connections use a semicolon-delimited key/value syntax with an optional `xbase://` prefix. The `path` option is required and must point to a directory that contains DBF/DBT/NTX/MDX assets.
+
+```
+xbase://path=/data/southwind;readonly=false;journal=wal;locking=file;deleted=hide
+```
+
+### Supported Options
+
+| Option | Values | Default | Description |
+| --- | --- | --- | --- |
+| `path` | Directory path | _(required)_ | Base directory containing the database files. |
+| `readonly` | `true`, `false` | `false` | When `true`, disables mutations and journaling. |
+| `journal` | `wal`, `on`, `off` | `wal` | Enables (`wal`/`on`) or disables (`off`) the write-ahead log. |
+| `journal.directory` | Directory path | Connection `path` | Overrides the directory where the journal file is stored. |
+| `journal.file` | File name | `xbase.trx` | Sets the journal file name. |
+| `journal.flushOnWrite` | `true`, `false` | `true` | Controls whether WAL writes flush buffers after each append. |
+| `journal.flushToDisk` | `true`, `false` | `true` | Enables durable flushes via `Flush(true)` for crash safety. |
+| `journal.autoResetOnCommit` | `true`, `false` | `true` | Truncates the journal after commits/rollbacks when `true`. |
+| `locking` | `none`, `file`, `record` | `file` | Chooses the lock manager mode for concurrent access. |
+| `deleted` | `hide`, `show` | `hide` | Determines whether soft-deleted rows are visible to queries. |
+
+Boolean options accept `true/false`, `on/off`, `yes/no`, or `1/0`.
+
+## Journaling Options
+
+Journaling is enabled by default through a write-ahead log (`xbase.trx`). `XBaseConnectionOptions` exposes a strongly typed view over the connection string so callers can inspect or generate the necessary settings.
+
+- `Journal.Mode`: `WriteAheadLog` when journaling is active, `Disabled` otherwise.
+- `Journal.DirectoryPath`: Directory containing the journal; defaults to the connection `path` when not specified.
+- `Journal.FileName`: File name of the WAL file.
+- `Journal.FlushOnWrite`: Applies `FlushAsync` on each append when `true`.
+- `Journal.FlushToDisk`: Issues `Flush(true)` for durable commits.
+- `Journal.AutoResetOnCommit`: Resets the WAL file after commit/rollback.
+
+`XBaseJournalOptions.CreateWalOptions(rootPath)` transforms the high-level settings into `WalJournalOptions` that are consumed by the core journaling engine. The method validates that the journal directory can be resolved from either `journal.directory` or the connection `path`.
+
+## Entity Framework Core Integration
+
+`DbContextOptionsBuilder.UseXBase(connectionString)` forwards the raw connection string to `XBaseConnection`. The provider parses the string into `XBaseConnectionOptions`, enabling applications to inspect `XBaseConnection.Options` for diagnostics or to construct a custom `IJournal` using the derived `WalJournalOptions`.
+
+Sample registration with dependency injection:
+
+```csharp
+services.AddDbContext<AppDbContext>(options =>
+{
+  options.UseXBase("xbase://path=/data/app;journal=wal");
+});
+```
+
+When running in read-only mode (`readonly=true`), journaling is automatically disabled even if `journal=wal` is supplied.

--- a/src/XBase.Data/Providers/XBaseConnection.cs
+++ b/src/XBase.Data/Providers/XBaseConnection.cs
@@ -41,11 +41,18 @@ public sealed class XBaseConnection : DbConnection
     _tableResolver = tableResolver ?? throw new ArgumentNullException(nameof(tableResolver));
   }
 
+  public XBaseConnectionOptions Options { get; private set; } = XBaseConnectionOptions.Default;
+
   [AllowNull]
   public override string ConnectionString
   {
     get => _connectionString;
-    set => _connectionString = value ?? string.Empty;
+    set
+    {
+      string newValue = value ?? string.Empty;
+      _connectionString = newValue;
+      Options = XBaseConnectionOptions.Parse(newValue);
+    }
   }
 
   public override string Database => "xBase";

--- a/src/XBase.Data/Providers/XBaseConnectionOptions.cs
+++ b/src/XBase.Data/Providers/XBaseConnectionOptions.cs
@@ -1,0 +1,103 @@
+using System;
+using XBase.Abstractions;
+
+namespace XBase.Data.Providers;
+
+public enum DeletedRecordVisibility
+{
+  Hide,
+  Show
+}
+
+public sealed class XBaseConnectionOptions
+{
+  public static XBaseConnectionOptions Default { get; } = new XBaseConnectionOptions(
+    rootPath: string.Empty,
+    isReadOnly: false,
+    lockingMode: LockingMode.File,
+    deletedRecordVisibility: DeletedRecordVisibility.Hide,
+    journal: XBaseJournalOptions.Default);
+
+  private XBaseConnectionOptions(
+    string rootPath,
+    bool isReadOnly,
+    LockingMode lockingMode,
+    DeletedRecordVisibility deletedRecordVisibility,
+    XBaseJournalOptions journal)
+  {
+    RootPath = rootPath ?? string.Empty;
+    IsReadOnly = isReadOnly;
+    LockingMode = lockingMode;
+    DeletedRecordVisibility = deletedRecordVisibility;
+    Journal = journal ?? XBaseJournalOptions.Default;
+  }
+
+  public string RootPath { get; }
+
+  public bool IsReadOnly { get; }
+
+  public LockingMode LockingMode { get; }
+
+  public DeletedRecordVisibility DeletedRecordVisibility { get; }
+
+  public XBaseJournalOptions Journal { get; }
+
+  public static XBaseConnectionOptions Parse(string? connectionString)
+  {
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+      return Default;
+    }
+
+    var builder = new XBaseConnectionStringBuilder(connectionString);
+
+    string? path = builder.Path;
+    if (string.IsNullOrWhiteSpace(path))
+    {
+      throw new InvalidOperationException("Connection string must include 'path'.");
+    }
+
+    bool isReadOnly = builder.ReadOnly ?? false;
+    LockingMode lockingMode = ParseLockingMode(builder.Locking);
+    DeletedRecordVisibility deletedVisibility = ParseDeletedVisibility(builder.Deleted);
+    XBaseJournalOptions journal = XBaseJournalOptions.FromBuilder(builder, path);
+
+    if (isReadOnly && journal.Mode != XBaseJournalMode.Disabled)
+    {
+      journal = XBaseJournalOptions.Disabled;
+    }
+
+    return new XBaseConnectionOptions(path, isReadOnly, lockingMode, deletedVisibility, journal);
+  }
+
+  private static LockingMode ParseLockingMode(string? value)
+  {
+    if (string.IsNullOrWhiteSpace(value))
+    {
+      return LockingMode.File;
+    }
+
+    return value.Trim().ToLowerInvariant() switch
+    {
+      "none" => LockingMode.None,
+      "file" => LockingMode.File,
+      "record" => LockingMode.Record,
+      _ => throw new InvalidOperationException($"Unsupported locking mode '{value}'.")
+    };
+  }
+
+  private static DeletedRecordVisibility ParseDeletedVisibility(string? value)
+  {
+    if (string.IsNullOrWhiteSpace(value))
+    {
+      return DeletedRecordVisibility.Hide;
+    }
+
+    return value.Trim().ToLowerInvariant() switch
+    {
+      "hide" => DeletedRecordVisibility.Hide,
+      "show" => DeletedRecordVisibility.Show,
+      _ => throw new InvalidOperationException($"Unsupported deleted record visibility '{value}'.")
+    };
+  }
+}

--- a/src/XBase.Data/Providers/XBaseConnectionStringBuilder.cs
+++ b/src/XBase.Data/Providers/XBaseConnectionStringBuilder.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Data.Common;
+
+namespace XBase.Data.Providers;
+
+public sealed class XBaseConnectionStringBuilder : DbConnectionStringBuilder
+{
+  public XBaseConnectionStringBuilder()
+  {
+  }
+
+  public XBaseConnectionStringBuilder(string connectionString)
+    : this()
+  {
+    if (!string.IsNullOrWhiteSpace(connectionString))
+    {
+      ConnectionString = Normalize(connectionString);
+    }
+  }
+
+  public string? Path => GetString("path");
+
+  public bool? ReadOnly => GetBoolean("readonly");
+
+  public string? Locking => GetString("locking");
+
+  public string? Deleted => GetString("deleted");
+
+  public string? Journal => GetString("journal");
+
+  public string? JournalDirectory => GetString("journal.directory");
+
+  public string? JournalFileName => GetString("journal.file");
+
+  public bool? GetBoolean(string keyword)
+  {
+    if (!TryGetValue(keyword, out object? raw))
+    {
+      return null;
+    }
+
+    if (raw is bool boolValue)
+    {
+      return boolValue;
+    }
+
+    if (raw is int intValue)
+    {
+      return intValue != 0;
+    }
+
+    if (raw is string text)
+    {
+      if (string.IsNullOrWhiteSpace(text))
+      {
+        return null;
+      }
+
+      return ParseBoolean(text.Trim());
+    }
+
+    throw new InvalidOperationException($"Value for '{keyword}' could not be interpreted as boolean.");
+  }
+
+  public string? GetString(string keyword)
+  {
+    if (!TryGetValue(keyword, out object? value) || value is null)
+    {
+      return null;
+    }
+
+    if (value is string text)
+    {
+      return text;
+    }
+
+    return Convert.ToString(value);
+  }
+
+  public static string Normalize(string connectionString)
+  {
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+      return string.Empty;
+    }
+
+    if (connectionString.StartsWith("xbase://", StringComparison.OrdinalIgnoreCase))
+    {
+      return connectionString.Substring("xbase://".Length);
+    }
+
+    return connectionString;
+  }
+
+  private static bool ParseBoolean(string value)
+  {
+    return value.ToLowerInvariant() switch
+    {
+      "1" => true,
+      "0" => false,
+      "true" => true,
+      "false" => false,
+      "yes" => true,
+      "no" => false,
+      "on" => true,
+      "off" => false,
+      _ => throw new InvalidOperationException($"Value '{value}' is not recognized as boolean.")
+    };
+  }
+}

--- a/src/XBase.Data/Providers/XBaseJournalOptions.cs
+++ b/src/XBase.Data/Providers/XBaseJournalOptions.cs
@@ -1,0 +1,128 @@
+using System;
+using XBase.Core.Transactions;
+
+namespace XBase.Data.Providers;
+
+public enum XBaseJournalMode
+{
+  Disabled,
+  WriteAheadLog
+}
+
+public sealed class XBaseJournalOptions
+{
+  public static XBaseJournalOptions Disabled { get; } = new XBaseJournalOptions(
+    XBaseJournalMode.Disabled,
+    directoryPath: string.Empty,
+    fileName: WalJournalDefaults.FileName,
+    flushOnWrite: false,
+    flushToDisk: false,
+    autoResetOnCommit: false);
+
+  public static XBaseJournalOptions Default { get; } = new XBaseJournalOptions(
+    XBaseJournalMode.WriteAheadLog,
+    directoryPath: string.Empty,
+    fileName: WalJournalDefaults.FileName,
+    flushOnWrite: WalJournalDefaults.FlushOnWrite,
+    flushToDisk: WalJournalDefaults.FlushToDisk,
+    autoResetOnCommit: WalJournalDefaults.AutoResetOnCommit);
+
+  public XBaseJournalOptions(
+    XBaseJournalMode mode,
+    string directoryPath,
+    string fileName,
+    bool flushOnWrite,
+    bool flushToDisk,
+    bool autoResetOnCommit)
+  {
+    Mode = mode;
+    DirectoryPath = directoryPath ?? string.Empty;
+    FileName = string.IsNullOrWhiteSpace(fileName) ? WalJournalDefaults.FileName : fileName;
+    FlushOnWrite = flushOnWrite;
+    FlushToDisk = flushToDisk;
+    AutoResetOnCommit = autoResetOnCommit;
+  }
+
+  public XBaseJournalMode Mode { get; }
+
+  public string DirectoryPath { get; }
+
+  public string FileName { get; }
+
+  public bool FlushOnWrite { get; }
+
+  public bool FlushToDisk { get; }
+
+  public bool AutoResetOnCommit { get; }
+
+  public WalJournalOptions CreateWalOptions(string rootPath)
+  {
+    if (Mode != XBaseJournalMode.WriteAheadLog)
+    {
+      throw new InvalidOperationException("Journal mode is disabled.");
+    }
+
+    string directory = string.IsNullOrWhiteSpace(DirectoryPath) ? rootPath : DirectoryPath;
+    if (string.IsNullOrWhiteSpace(directory))
+    {
+      throw new InvalidOperationException("Journal directory must be resolved from either journal.directory or path.");
+    }
+
+    return new WalJournalOptions
+    {
+      DirectoryPath = directory,
+      JournalFileName = FileName,
+      FlushOnWrite = FlushOnWrite,
+      FlushToDisk = FlushToDisk,
+      AutoResetOnCommit = AutoResetOnCommit
+    };
+  }
+
+  internal static XBaseJournalOptions FromBuilder(XBaseConnectionStringBuilder builder, string rootPath)
+  {
+    string? journalValue = builder.Journal;
+    XBaseJournalMode mode = ParseJournalMode(journalValue);
+    if (mode == XBaseJournalMode.Disabled)
+    {
+      return Disabled;
+    }
+
+    string directory = builder.JournalDirectory ?? rootPath;
+    string fileName = builder.JournalFileName ?? WalJournalDefaults.FileName;
+    bool flushOnWrite = builder.GetBoolean("journal.flushOnWrite") ?? WalJournalDefaults.FlushOnWrite;
+    bool flushToDisk = builder.GetBoolean("journal.flushToDisk") ?? WalJournalDefaults.FlushToDisk;
+    bool autoResetOnCommit = builder.GetBoolean("journal.autoResetOnCommit") ?? WalJournalDefaults.AutoResetOnCommit;
+
+    return new XBaseJournalOptions(mode, directory, fileName, flushOnWrite, flushToDisk, autoResetOnCommit);
+  }
+
+  private static XBaseJournalMode ParseJournalMode(string? value)
+  {
+    if (string.IsNullOrWhiteSpace(value))
+    {
+      return XBaseJournalMode.WriteAheadLog;
+    }
+
+    return value.Trim().ToLowerInvariant() switch
+    {
+      "on" => XBaseJournalMode.WriteAheadLog,
+      "true" => XBaseJournalMode.WriteAheadLog,
+      "wal" => XBaseJournalMode.WriteAheadLog,
+      "writeaheadlog" => XBaseJournalMode.WriteAheadLog,
+      "enabled" => XBaseJournalMode.WriteAheadLog,
+      "off" => XBaseJournalMode.Disabled,
+      "false" => XBaseJournalMode.Disabled,
+      "disabled" => XBaseJournalMode.Disabled,
+      "none" => XBaseJournalMode.Disabled,
+      _ => throw new InvalidOperationException($"Unsupported journal mode '{value}'.")
+    };
+  }
+
+  private static class WalJournalDefaults
+  {
+    public const string FileName = "xbase.trx";
+    public const bool FlushOnWrite = true;
+    public const bool FlushToDisk = true;
+    public const bool AutoResetOnCommit = true;
+  }
+}

--- a/tasks.md
+++ b/tasks.md
@@ -25,7 +25,7 @@
 ## M5 – Provider Integrations ⏳
 - [x] Complete ADO.NET command execution pipeline (parser, plan builder, `XBaseDataReader`) returning real records.
 - [x] Implement EF Core provider services (type mappings, query translation, change tracking) backed by integration tests.
-- [ ] Deliver connection string/journaling options surface plus configuration docs.
+- [x] Deliver connection string/journaling options surface plus configuration docs.
 
 ## M6 – Tooling, Docs & Release ⏳
 - [ ] Expand CLI with `dbfdump`, `dbfpack`, `dbfreindex`, `dbfconvert`, including smoke tests.

--- a/tests/XBase.Data.Tests/XBaseConnectionOptionsTests.cs
+++ b/tests/XBase.Data.Tests/XBaseConnectionOptionsTests.cs
@@ -1,0 +1,75 @@
+using System;
+using XBase.Data.Providers;
+
+namespace XBase.Data.Tests;
+
+public sealed class XBaseConnectionOptionsTests
+{
+  [Fact]
+  public void Parse_WithWalSettings_BuildsOptions()
+  {
+    const string connectionString = "xbase://path=/var/db;readonly=false;journal=wal;journal.directory=/var/db/journal;journal.file=custom.trx;journal.flushOnWrite=false;journal.flushToDisk=false;journal.autoResetOnCommit=false";
+
+    XBaseConnectionOptions options = XBaseConnectionOptions.Parse(connectionString);
+
+    Assert.Equal("/var/db", options.RootPath);
+    Assert.False(options.IsReadOnly);
+    Assert.Equal(XBaseJournalMode.WriteAheadLog, options.Journal.Mode);
+    Assert.Equal("/var/db/journal", options.Journal.DirectoryPath);
+    Assert.Equal("custom.trx", options.Journal.FileName);
+    Assert.False(options.Journal.FlushOnWrite);
+    Assert.False(options.Journal.FlushToDisk);
+    Assert.False(options.Journal.AutoResetOnCommit);
+  }
+
+  [Fact]
+  public void Parse_ReadOnlyForcesNoJournal()
+  {
+    const string connectionString = "xbase://path=/var/db;readonly=true;journal=on";
+
+    XBaseConnectionOptions options = XBaseConnectionOptions.Parse(connectionString);
+
+    Assert.True(options.IsReadOnly);
+    Assert.Equal(XBaseJournalMode.Disabled, options.Journal.Mode);
+  }
+
+  [Fact]
+  public void Parse_WithoutPath_Throws()
+  {
+    Assert.Throws<InvalidOperationException>(() => XBaseConnectionOptions.Parse("journal=on"));
+  }
+
+  [Fact]
+  public void JournalOptions_CreateWalOptions_UsesRootPath()
+  {
+    var options = new XBaseJournalOptions(
+      XBaseJournalMode.WriteAheadLog,
+      directoryPath: string.Empty,
+      fileName: "example.trx",
+      flushOnWrite: true,
+      flushToDisk: true,
+      autoResetOnCommit: true);
+
+    var walOptions = options.CreateWalOptions("/var/db");
+
+    Assert.Equal("/var/db", walOptions.DirectoryPath);
+    Assert.Equal("example.trx", walOptions.JournalFileName);
+    Assert.True(walOptions.FlushOnWrite);
+    Assert.True(walOptions.FlushToDisk);
+    Assert.True(walOptions.AutoResetOnCommit);
+  }
+
+  [Fact]
+  public void JournalOptions_CreateWalOptions_WithoutDirectory_Throws()
+  {
+    var options = new XBaseJournalOptions(
+      XBaseJournalMode.WriteAheadLog,
+      directoryPath: string.Empty,
+      fileName: "example.trx",
+      flushOnWrite: true,
+      flushToDisk: true,
+      autoResetOnCommit: true);
+
+    Assert.Throws<InvalidOperationException>(() => options.CreateWalOptions(string.Empty));
+  }
+}

--- a/tests/XBase.Data.Tests/XBaseConnectionTests.cs
+++ b/tests/XBase.Data.Tests/XBaseConnectionTests.cs
@@ -57,6 +57,21 @@ public sealed class XBaseConnectionTests
     Assert.Equal(1, journal.RollbackCallCount);
   }
 
+  [Fact]
+  public void ConnectionString_ParseOptions()
+  {
+    using var connection = new XBaseConnection();
+
+    connection.ConnectionString = "xbase://path=/data/db;readonly=true;journal=off;locking=record;deleted=show";
+
+    Assert.Equal("xbase://path=/data/db;readonly=true;journal=off;locking=record;deleted=show", connection.ConnectionString);
+    Assert.Equal("/data/db", connection.Options.RootPath);
+    Assert.True(connection.Options.IsReadOnly);
+    Assert.Equal(LockingMode.Record, connection.Options.LockingMode);
+    Assert.Equal(DeletedRecordVisibility.Show, connection.Options.DeletedRecordVisibility);
+    Assert.Equal(XBaseJournalMode.Disabled, connection.Options.Journal.Mode);
+  }
+
   private sealed class FakeJournal : IJournal
   {
     public int BeginCallCount { get; private set; }

--- a/tests/XBase.EFCore.Tests/UseXBaseTests.cs
+++ b/tests/XBase.EFCore.Tests/UseXBaseTests.cs
@@ -65,7 +65,7 @@ public sealed class UseXBaseTests
     ServiceProvider provider = services.BuildServiceProvider();
 
     var optionsBuilder = new DbContextOptionsBuilder<SampleContext>();
-    optionsBuilder.UseXBase("Data Source=memory");
+    optionsBuilder.UseXBase("xbase://path=memory");
     optionsBuilder.UseInternalServiceProvider(provider);
 
     using var context = new SampleContext(optionsBuilder.Options);


### PR DESCRIPTION
## Summary
- add `XBaseConnectionOptions`/`XBaseJournalOptions` to parse connection strings and surface journaling settings on `XBaseConnection`
- cover the new options with unit tests, adjust EF Core provider tests, and link configuration docs from the README
- document connection string and WAL configuration details and mark the M5 deliverable complete in the tracker

## Testing
- dotnet format
- dotnet test xBase.sln --configuration Release

------
https://chatgpt.com/codex/tasks/task_e_68dd47f87ac8832295bded7a4e962d4d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced comprehensive connection string options (path, readonly, locking, deleted visibility, journaling/WAL), including support for an xbase:// prefix.
  * Connection objects now expose parsed configuration for easier inspection.
  * EF Core integration accepts the new connection string format via UseXBase.

* Documentation
  * Added a detailed Configuration Guide covering connection strings, options, journaling behavior, and EF Core setup.
  * Linked the new guide from the README.

* Tests
  * Added tests validating connection string parsing, read-only behavior, journaling options, and EF Core usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->