### PR TITLE
feat: expand dbf cli support

### DIFF
--- a/src/XBase.Core/Table/DbfColumnFactory.cs
+++ b/src/XBase.Core/Table/DbfColumnFactory.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using XBase.Abstractions;
+
+namespace XBase.Core.Table;
+
+public readonly record struct DbfFieldLayout(DbfFieldSchema Schema, int Offset);
+
+public static class DbfColumnFactory
+{
+  private static readonly Encoding Ascii = Encoding.ASCII;
+
+  public static IReadOnlyList<TableColumn> CreateColumns(DbfTableDescriptor descriptor) =>
+    CreateColumns(descriptor, requestedColumns: null, encodingOverride: null);
+
+  public static IReadOnlyList<TableColumn> CreateColumns(
+    DbfTableDescriptor descriptor,
+    IReadOnlyList<string>? requestedColumns,
+    Encoding? encodingOverride = null)
+  {
+    if (descriptor is null)
+    {
+      throw new ArgumentNullException(nameof(descriptor));
+    }
+
+    IReadOnlyDictionary<string, DbfFieldLayout> layout = CreateLayoutLookup(descriptor);
+    Encoding encoding = encodingOverride ?? DbfEncodingRegistry.Resolve(descriptor.LanguageDriverId);
+
+    IEnumerable<DbfFieldLayout> selection;
+    if (requestedColumns is null || requestedColumns.Count == 0)
+    {
+      selection = descriptor.FieldSchemas.Select(schema => layout[schema.Name]);
+    }
+    else
+    {
+      var buffer = new List<DbfFieldLayout>(requestedColumns.Count);
+      foreach (string column in requestedColumns)
+      {
+        if (!layout.TryGetValue(column, out DbfFieldLayout fieldLayout))
+        {
+          throw new InvalidOperationException(
+            $"Column '{column}' was not found in table '{descriptor.Name}'.");
+        }
+
+        buffer.Add(fieldLayout);
+      }
+
+      selection = buffer;
+    }
+
+    return selection.Select(entry => CreateColumn(entry, encoding)).ToArray();
+  }
+
+  public static IReadOnlyDictionary<string, DbfFieldLayout> CreateLayoutLookup(DbfTableDescriptor descriptor)
+  {
+    if (descriptor is null)
+    {
+      throw new ArgumentNullException(nameof(descriptor));
+    }
+
+    var layout = new Dictionary<string, DbfFieldLayout>(StringComparer.OrdinalIgnoreCase);
+    int offset = 1;
+
+    foreach (DbfFieldSchema schema in descriptor.FieldSchemas)
+    {
+      layout[schema.Name] = new DbfFieldLayout(schema, offset);
+      offset += schema.Length;
+    }
+
+    return layout;
+  }
+
+  private static TableColumn CreateColumn(DbfFieldLayout layout, Encoding encoding)
+  {
+    Type clrType = ResolveClrType(layout.Schema);
+
+    return new TableColumn(
+      layout.Schema.Name,
+      clrType,
+      record =>
+      {
+        ReadOnlySpan<byte> buffer = record.IsSingleSegment
+          ? record.FirstSpan
+          : record.ToArray();
+
+        int fieldOffset = layout.Offset;
+        int fieldLength = layout.Schema.Length;
+        if (buffer.Length < fieldOffset + fieldLength)
+        {
+          return null;
+        }
+
+        ReadOnlySpan<byte> slice = buffer.Slice(fieldOffset, fieldLength);
+        return ExtractValue(slice, layout.Schema, encoding, clrType);
+      });
+  }
+
+  private static Type ResolveClrType(DbfFieldSchema schema)
+  {
+    char type = char.ToUpperInvariant(schema.Type);
+
+    return type switch
+    {
+      'C' or 'V' or 'W' or 'G' or 'P' => typeof(string),
+      'L' => typeof(bool),
+      'D' => typeof(DateTime),
+      'I' => typeof(int),
+      'B' or 'O' => typeof(double),
+      'F' => typeof(double),
+      'Y' => typeof(decimal),
+      'N' when schema.DecimalCount == 0 && schema.Length <= 9 => typeof(int),
+      'N' when schema.DecimalCount == 0 && schema.Length <= 18 => typeof(long),
+      'N' => typeof(decimal),
+      _ => typeof(string)
+    };
+  }
+
+  private static object? ExtractValue(
+    ReadOnlySpan<byte> slice,
+    DbfFieldSchema schema,
+    Encoding encoding,
+    Type clrType)
+  {
+    char type = char.ToUpperInvariant(schema.Type);
+
+    switch (type)
+    {
+      case 'C':
+      case 'V':
+      case 'W':
+      case 'G':
+      case 'P':
+        return ReadCharacter(slice, encoding, schema.IsNullable);
+      case 'L':
+        return ReadLogical(slice, schema.IsNullable);
+      case 'D':
+        return ReadDate(slice, schema.IsNullable);
+      case 'I':
+        return ReadIntegerBinary(slice, schema.IsNullable);
+      case 'B':
+      case 'O':
+        return ReadDoubleBinary(slice, schema.IsNullable);
+      case 'Y':
+      case 'N':
+      case 'F':
+        return ReadNumeric(slice, schema, clrType);
+      default:
+        string fallback = encoding.GetString(slice).TrimEnd(' ', '\0');
+        if (fallback.Length == 0 && schema.IsNullable)
+        {
+          return null;
+        }
+
+        return fallback;
+    }
+  }
+
+  private static object? ReadNumeric(ReadOnlySpan<byte> slice, DbfFieldSchema schema, Type clrType)
+  {
+    string text = Ascii.GetString(slice).Trim();
+    if (text.Length == 0)
+    {
+      return schema.IsNullable ? null : GetDefaultNumeric(clrType);
+    }
+
+    if (clrType == typeof(int))
+    {
+      if (int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int @int))
+      {
+        return @int;
+      }
+    }
+    else if (clrType == typeof(long))
+    {
+      if (long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out long @long))
+      {
+        return @long;
+      }
+    }
+    else if (clrType == typeof(decimal))
+    {
+      if (decimal.TryParse(
+        text,
+        NumberStyles.Float | NumberStyles.AllowLeadingSign,
+        CultureInfo.InvariantCulture,
+        out decimal @decimal))
+      {
+        return @decimal;
+      }
+    }
+    else if (clrType == typeof(double))
+    {
+      if (double.TryParse(
+        text,
+        NumberStyles.Float | NumberStyles.AllowLeadingSign,
+        CultureInfo.InvariantCulture,
+        out double @double))
+      {
+        return @double;
+      }
+    }
+
+    return schema.IsNullable ? null : GetDefaultNumeric(clrType);
+  }
+
+  private static object GetDefaultNumeric(Type clrType)
+  {
+    if (clrType == typeof(int))
+    {
+      return 0;
+    }
+
+    if (clrType == typeof(long))
+    {
+      return 0L;
+    }
+
+    if (clrType == typeof(decimal))
+    {
+      return 0m;
+    }
+
+    if (clrType == typeof(double))
+    {
+      return 0d;
+    }
+
+    return 0;
+  }
+
+  private static object? ReadIntegerBinary(ReadOnlySpan<byte> slice, bool isNullable)
+  {
+    if (slice.Length < 4)
+    {
+      return isNullable ? null : 0;
+    }
+
+    return BinaryPrimitives.ReadInt32LittleEndian(slice);
+  }
+
+  private static object? ReadDoubleBinary(ReadOnlySpan<byte> slice, bool isNullable)
+  {
+    if (slice.Length < 8)
+    {
+      return isNullable ? null : 0d;
+    }
+
+    long bits = BinaryPrimitives.ReadInt64LittleEndian(slice);
+    return BitConverter.Int64BitsToDouble(bits);
+  }
+
+  private static object? ReadDate(ReadOnlySpan<byte> slice, bool isNullable)
+  {
+    string text = Ascii.GetString(slice).Trim();
+    if (text.Length == 0)
+    {
+      return isNullable ? null : DateTime.MinValue;
+    }
+
+    if (text.Length == 8 &&
+      int.TryParse(text[..4], NumberStyles.Integer, CultureInfo.InvariantCulture, out int year) &&
+      int.TryParse(text.Substring(4, 2), NumberStyles.Integer, CultureInfo.InvariantCulture, out int month) &&
+      int.TryParse(text.Substring(6, 2), NumberStyles.Integer, CultureInfo.InvariantCulture, out int day))
+    {
+      try
+      {
+        return new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Unspecified);
+      }
+      catch (ArgumentOutOfRangeException)
+      {
+        return isNullable ? null : DateTime.MinValue;
+      }
+    }
+
+    return isNullable ? null : DateTime.MinValue;
+  }
+
+  private static object? ReadLogical(ReadOnlySpan<byte> slice, bool isNullable)
+  {
+    if (slice.IsEmpty)
+    {
+      return isNullable ? null : false;
+    }
+
+    char indicator = char.ToUpperInvariant((char)slice[0]);
+    return indicator switch
+    {
+      'T' or 'Y' or '1' => true,
+      'F' or 'N' or '0' => false,
+      _ => isNullable ? null : false
+    };
+  }
+
+  private static object? ReadCharacter(ReadOnlySpan<byte> slice, Encoding encoding, bool isNullable)
+  {
+    string text = encoding.GetString(slice).TrimEnd(' ', '\0');
+    if (text.Length == 0 && isNullable)
+    {
+      return null;
+    }
+
+    return text;
+  }
+}

--- a/src/XBase.Core/Table/DbfEncodingRegistry.cs
+++ b/src/XBase.Core/Table/DbfEncodingRegistry.cs
@@ -73,4 +73,19 @@ public static class DbfEncodingRegistry
 
     return DefaultEncoding;
   }
+
+  public static bool TryGetLanguageDriverId(int codePage, out byte languageDriverId)
+  {
+    foreach (KeyValuePair<byte, int> mapping in CodePageByLanguageDriverId)
+    {
+      if (mapping.Value == codePage)
+      {
+        languageDriverId = mapping.Key;
+        return true;
+      }
+    }
+
+    languageDriverId = default;
+    return false;
+  }
 }

--- a/src/XBase.Data/Providers/SqlTableResolver.cs
+++ b/src/XBase.Data/Providers/SqlTableResolver.cs
@@ -1,11 +1,7 @@
 using System;
-using System.Buffers;
-using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using XBase.Abstractions;
@@ -15,7 +11,6 @@ namespace XBase.Data.Providers;
 
 public sealed class SqlTableResolver : ITableResolver
 {
-  private static readonly Encoding Ascii = Encoding.ASCII;
 
   private readonly Func<XBaseConnectionOptions> _optionsAccessor;
   private readonly DbfTableLoader _tableLoader;
@@ -43,287 +38,12 @@ public sealed class SqlTableResolver : ITableResolver
 
     string tablePath = ResolveTablePath(options.RootPath, statement.TableName);
     DbfTableDescriptor descriptor = _tableLoader.LoadDbf(tablePath);
-    IReadOnlyList<TableColumn> columns = BuildColumns(descriptor, statement.Columns);
+    IReadOnlyList<TableColumn> columns = DbfColumnFactory.CreateColumns(descriptor, statement.Columns);
     bool includeDeleted = options.DeletedRecordVisibility == DeletedRecordVisibility.Show;
 
     var cursorOptions = new CursorOptions(includeDeleted, Limit: null, Offset: null);
     var result = new TableResolveResult(descriptor, columns, cursorOptions);
     return ValueTask.FromResult<TableResolveResult?>(result);
-  }
-
-  private static IReadOnlyList<TableColumn> BuildColumns(
-    DbfTableDescriptor descriptor,
-    IReadOnlyList<string>? requestedColumns)
-  {
-    Dictionary<string, FieldLayout> layout = BuildLayout(descriptor);
-    Encoding encoding = DbfEncodingRegistry.Resolve(descriptor.LanguageDriverId);
-
-    if (requestedColumns is null || requestedColumns.Count == 0)
-    {
-      return descriptor.FieldSchemas
-        .Select(schema => CreateColumn(layout[schema.Name], encoding))
-        .ToArray();
-    }
-
-    List<TableColumn> columns = new(requestedColumns.Count);
-    foreach (string columnName in requestedColumns)
-    {
-      if (!layout.TryGetValue(columnName, out FieldLayout layoutEntry))
-      {
-        throw new InvalidOperationException(
-          $"Column '{columnName}' was not found in table '{descriptor.Name}'.");
-      }
-
-      columns.Add(CreateColumn(layoutEntry, encoding));
-    }
-
-    return columns;
-  }
-
-  private static TableColumn CreateColumn(FieldLayout layout, Encoding encoding)
-  {
-    Type clrType = ResolveClrType(layout.Schema);
-
-    return new TableColumn(
-      layout.Schema.Name,
-      clrType,
-      record =>
-      {
-        ReadOnlySpan<byte> buffer = record.IsSingleSegment
-          ? record.FirstSpan
-          : record.ToArray();
-
-        int fieldOffset = layout.Offset;
-        int fieldLength = layout.Schema.Length;
-        if (buffer.Length < fieldOffset + fieldLength)
-        {
-          return null;
-        }
-
-        ReadOnlySpan<byte> slice = buffer.Slice(fieldOffset, fieldLength);
-        return ExtractValue(slice, layout.Schema, encoding, clrType);
-      });
-  }
-
-  private static object? ExtractValue(
-    ReadOnlySpan<byte> slice,
-    DbfFieldSchema schema,
-    Encoding encoding,
-    Type clrType)
-  {
-    char type = char.ToUpperInvariant(schema.Type);
-
-    switch (type)
-    {
-      case 'C':
-      case 'V':
-      case 'W':
-      case 'G':
-      case 'P':
-        return ReadCharacter(slice, encoding, schema.IsNullable);
-      case 'L':
-        return ReadLogical(slice, schema.IsNullable);
-      case 'D':
-        return ReadDate(slice, schema.IsNullable);
-      case 'I':
-        return ReadIntegerBinary(slice, schema.IsNullable);
-      case 'B':
-      case 'O':
-        return ReadDoubleBinary(slice, schema.IsNullable);
-      case 'Y':
-      case 'N':
-      case 'F':
-        return ReadNumeric(slice, schema, clrType);
-      default:
-        string fallback = encoding.GetString(slice).TrimEnd(' ', '\0');
-        if (fallback.Length == 0 && schema.IsNullable)
-        {
-          return null;
-        }
-
-        return fallback;
-    }
-  }
-
-  private static object? ReadNumeric(ReadOnlySpan<byte> slice, DbfFieldSchema schema, Type clrType)
-  {
-    string text = Ascii.GetString(slice).Trim();
-    if (text.Length == 0)
-    {
-      return schema.IsNullable ? null : GetDefaultNumeric(clrType);
-    }
-
-    if (clrType == typeof(int))
-    {
-      if (int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int @int))
-      {
-        return @int;
-      }
-    }
-    else if (clrType == typeof(long))
-    {
-      if (long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out long @long))
-      {
-        return @long;
-      }
-    }
-    else if (clrType == typeof(decimal))
-    {
-      if (decimal.TryParse(
-        text,
-        NumberStyles.Float | NumberStyles.AllowLeadingSign,
-        CultureInfo.InvariantCulture,
-        out decimal @decimal))
-      {
-        return @decimal;
-      }
-    }
-    else if (clrType == typeof(double))
-    {
-      if (double.TryParse(
-        text,
-        NumberStyles.Float | NumberStyles.AllowLeadingSign,
-        CultureInfo.InvariantCulture,
-        out double @double))
-      {
-        return @double;
-      }
-    }
-
-    return schema.IsNullable ? null : GetDefaultNumeric(clrType);
-  }
-
-  private static object GetDefaultNumeric(Type clrType)
-  {
-    if (clrType == typeof(int))
-    {
-      return 0;
-    }
-
-    if (clrType == typeof(long))
-    {
-      return 0L;
-    }
-
-    if (clrType == typeof(decimal))
-    {
-      return 0m;
-    }
-
-    if (clrType == typeof(double))
-    {
-      return 0d;
-    }
-
-    return 0;
-  }
-
-  private static object? ReadIntegerBinary(ReadOnlySpan<byte> slice, bool isNullable)
-  {
-    if (slice.Length < 4)
-    {
-      return isNullable ? null : 0;
-    }
-
-    return BinaryPrimitives.ReadInt32LittleEndian(slice);
-  }
-
-  private static object? ReadDoubleBinary(ReadOnlySpan<byte> slice, bool isNullable)
-  {
-    if (slice.Length < 8)
-    {
-      return isNullable ? null : 0d;
-    }
-
-    long bits = BinaryPrimitives.ReadInt64LittleEndian(slice);
-    return BitConverter.Int64BitsToDouble(bits);
-  }
-
-  private static object? ReadDate(ReadOnlySpan<byte> slice, bool isNullable)
-  {
-    string text = Ascii.GetString(slice).Trim();
-    if (text.Length == 0)
-    {
-      return isNullable ? null : DateTime.MinValue;
-    }
-
-    if (text.Length == 8 &&
-      int.TryParse(text[..4], NumberStyles.Integer, CultureInfo.InvariantCulture, out int year) &&
-      int.TryParse(text.Substring(4, 2), NumberStyles.Integer, CultureInfo.InvariantCulture, out int month) &&
-      int.TryParse(text.Substring(6, 2), NumberStyles.Integer, CultureInfo.InvariantCulture, out int day))
-    {
-      try
-      {
-        return new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Unspecified);
-      }
-      catch (ArgumentOutOfRangeException)
-      {
-        return isNullable ? null : DateTime.MinValue;
-      }
-    }
-
-    return isNullable ? null : DateTime.MinValue;
-  }
-
-  private static object? ReadLogical(ReadOnlySpan<byte> slice, bool isNullable)
-  {
-    if (slice.IsEmpty)
-    {
-      return isNullable ? null : false;
-    }
-
-    char indicator = char.ToUpperInvariant((char)slice[0]);
-    return indicator switch
-    {
-      'T' or 'Y' or '1' => true,
-      'F' or 'N' or '0' => false,
-      _ => isNullable ? null : false
-    };
-  }
-
-  private static object? ReadCharacter(ReadOnlySpan<byte> slice, Encoding encoding, bool isNullable)
-  {
-    string text = encoding.GetString(slice).TrimEnd(' ', '\0');
-    if (text.Length == 0 && isNullable)
-    {
-      return null;
-    }
-
-    return text;
-  }
-
-  private static Dictionary<string, FieldLayout> BuildLayout(DbfTableDescriptor descriptor)
-  {
-    var layout = new Dictionary<string, FieldLayout>(StringComparer.OrdinalIgnoreCase);
-    int offset = 1; // skip deletion flag
-
-    foreach (DbfFieldSchema schema in descriptor.FieldSchemas)
-    {
-      layout[schema.Name] = new FieldLayout(schema, offset);
-      offset += schema.Length;
-    }
-
-    return layout;
-  }
-
-  private static Type ResolveClrType(DbfFieldSchema schema)
-  {
-    char type = char.ToUpperInvariant(schema.Type);
-
-    return type switch
-    {
-      'C' or 'V' or 'W' or 'G' or 'P' => typeof(string),
-      'L' => typeof(bool),
-      'D' => typeof(DateTime),
-      'I' => typeof(int),
-      'B' or 'O' => typeof(double),
-      'F' => typeof(double),
-      'Y' => typeof(decimal),
-      'N' when schema.DecimalCount == 0 && schema.Length <= 9 => typeof(int),
-      'N' when schema.DecimalCount == 0 && schema.Length <= 18 => typeof(long),
-      'N' => typeof(decimal),
-      _ => typeof(string)
-    };
   }
 
   private static string ResolveTablePath(string rootPath, string tableName)
@@ -519,8 +239,6 @@ public sealed class SqlTableResolver : ITableResolver
 
     return -1;
   }
-
-  private readonly record struct FieldLayout(DbfFieldSchema Schema, int Offset);
 
   private sealed record SelectStatement(string TableName, IReadOnlyList<string>? Columns);
 }

--- a/src/XBase.Tools/Program.cs
+++ b/src/XBase.Tools/Program.cs
@@ -748,7 +748,7 @@ static async Task<int> DbfConvertAsync(Queue<string> arguments)
     }
   }
 
-  string defaultOutputName = Path.Combine(root, table + ".utf8.dbf");
+  string defaultOutputName = Path.Combine(root, table + ".dbf");
   string? resolvedOutput = outputCandidate is null
     ? defaultOutputName
     : ResolveOutputPath(outputCandidate, table, "dbf") ?? defaultOutputName;

--- a/tasks.md
+++ b/tasks.md
@@ -27,8 +27,8 @@
 - [x] Implement EF Core provider services (type mappings, query translation, change tracking) backed by integration tests.
 - [x] Deliver connection string/journaling options surface plus configuration docs.
 
-## M6 – Tooling, Docs & Release ✅
+## M6 – Tooling, Docs & Release ⏳
 - [x] Expand CLI with `dbfdump`, `dbfpack`, `dbfreindex`, `dbfconvert`, including smoke tests.
-- [x] Author remaining documentation set (ROADMAP.md, CODEPAGES.md, INDEXES.md, TRANSACTIONS.md, provider cookbooks).
-- [x] Establish CI pipeline, packaging strategy, and release checklist for Phase A GA.
+- [ ] Author remaining documentation set (ROADMAP.md, CODEPAGES.md, INDEXES.md, TRANSACTIONS.md, provider cookbooks).
+- [ ] Establish CI pipeline, packaging strategy, and release checklist for Phase A GA.
 - [x] Hardened `dbfconvert` output resolution so directory targets emit `<table>.dbf`, restoring green release tests.

--- a/tests/XBase.Tools.Tests/DbfCommandTests.cs
+++ b/tests/XBase.Tools.Tests/DbfCommandTests.cs
@@ -1,0 +1,310 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using XBase.Core.Table;
+using XBase.TestSupport;
+
+namespace XBase.Tools.Tests;
+
+public sealed class DbfCommandTests
+{
+  [Fact]
+  public async Task Dbfdump_WritesCsvToDirectory()
+  {
+    string repoRoot = ToolTestContext.RepoRoot;
+    string toolAssembly = ToolTestContext.GetToolAssemblyPath();
+    Assert.True(File.Exists(toolAssembly));
+
+    string workspace = Path.Combine(Path.GetTempPath(), $"xbase-dbfdump-{Guid.NewGuid():N}");
+    Directory.CreateDirectory(workspace);
+
+    try
+    {
+      string tablePath = DbfTestBuilder.CreateTable(
+        workspace,
+        "customers",
+        (false, "A001"),
+        (true, "A002"),
+        (false, "A003"));
+      string outputDirectory = Path.Combine(workspace, "exports");
+
+      using var process = new Process
+      {
+        StartInfo = new ProcessStartInfo
+        {
+          FileName = "dotnet",
+          ArgumentList =
+          {
+            toolAssembly,
+            "dbfdump",
+            tablePath,
+            "--output",
+            outputDirectory,
+            "--format",
+            "csv",
+            "--include-deleted"
+          },
+          RedirectStandardOutput = true,
+          RedirectStandardError = true,
+          UseShellExecute = false,
+          WorkingDirectory = repoRoot
+        }
+      };
+
+      process.Start();
+      Task<string> stdout = process.StandardOutput.ReadToEndAsync();
+      Task<string> stderr = process.StandardError.ReadToEndAsync();
+      await process.WaitForExitAsync();
+
+      string error = await stderr;
+      Assert.Equal(0, process.ExitCode);
+
+      string csvPath = Path.Combine(outputDirectory, "customers.csv");
+      Assert.True(File.Exists(csvPath), $"CSV export was not written to {csvPath}.");
+
+      string[] lines = await File.ReadAllLinesAsync(csvPath);
+      Assert.True(lines.Length >= 2, "CSV export did not contain the expected rows.");
+      Assert.Equal("CODE", lines[0]);
+      Assert.Contains("A001", lines[1]);
+      Assert.Contains("Exported", error);
+    }
+    finally
+    {
+      if (Directory.Exists(workspace))
+      {
+        Directory.Delete(workspace, recursive: true);
+      }
+    }
+  }
+
+  [Fact]
+  public async Task DbfPack_RemovesDeletedRecords()
+  {
+    string repoRoot = ToolTestContext.RepoRoot;
+    string toolAssembly = ToolTestContext.GetToolAssemblyPath();
+    Assert.True(File.Exists(toolAssembly));
+
+    string workspace = Path.Combine(Path.GetTempPath(), $"xbase-dbfpack-{Guid.NewGuid():N}");
+    Directory.CreateDirectory(workspace);
+
+    try
+    {
+      string tablePath = DbfTestBuilder.CreateTable(
+        workspace,
+        "orders",
+        (false, "A001"),
+        (true, "A002"),
+        (false, "A003"));
+
+      var loader = new DbfTableLoader();
+      DbfTableDescriptor before = loader.LoadDbf(tablePath);
+      (uint totalBefore, uint deletedBefore) = CountRecords(
+        tablePath,
+        before.HeaderLength,
+        before.RecordLength);
+      Assert.Equal<uint>(3, totalBefore);
+      Assert.Equal<uint>(1, deletedBefore);
+
+      using var process = new Process
+      {
+        StartInfo = new ProcessStartInfo
+        {
+          FileName = "dotnet",
+          ArgumentList = { toolAssembly, "dbfpack", tablePath },
+          RedirectStandardOutput = true,
+          RedirectStandardError = true,
+          UseShellExecute = false,
+          WorkingDirectory = repoRoot
+        }
+      };
+
+      process.Start();
+      Task<string> stdout = process.StandardOutput.ReadToEndAsync();
+      Task<string> stderr = process.StandardError.ReadToEndAsync();
+      await process.WaitForExitAsync();
+
+      string output = await stdout;
+      string error = await stderr;
+      Assert.Equal(0, process.ExitCode);
+      Assert.True(output.Contains("Pack completed", StringComparison.OrdinalIgnoreCase) ||
+        error.Contains("Pack completed", StringComparison.OrdinalIgnoreCase));
+
+      DbfTableDescriptor after = loader.LoadDbf(tablePath);
+      (uint totalAfter, uint deletedAfter) = CountRecords(
+        tablePath,
+        after.HeaderLength,
+        after.RecordLength);
+      Assert.Equal<uint>(2, totalAfter);
+      Assert.Equal<uint>(0, deletedAfter);
+    }
+    finally
+    {
+      if (Directory.Exists(workspace))
+      {
+        Directory.Delete(workspace, recursive: true);
+      }
+    }
+  }
+
+  [Fact]
+  public async Task DbfReindex_SucceedsWithoutIndexes()
+  {
+    string repoRoot = ToolTestContext.RepoRoot;
+    string toolAssembly = ToolTestContext.GetToolAssemblyPath();
+    Assert.True(File.Exists(toolAssembly));
+
+    string workspace = Path.Combine(Path.GetTempPath(), $"xbase-dbfreindex-{Guid.NewGuid():N}");
+    Directory.CreateDirectory(workspace);
+
+    try
+    {
+      string tablePath = DbfTestBuilder.CreateTable(
+        workspace,
+        "inventory",
+        (false, "A001"),
+        (false, "A002"));
+
+      using var process = new Process
+      {
+        StartInfo = new ProcessStartInfo
+        {
+          FileName = "dotnet",
+          ArgumentList = { toolAssembly, "dbfreindex", tablePath },
+          RedirectStandardOutput = true,
+          RedirectStandardError = true,
+          UseShellExecute = false,
+          WorkingDirectory = repoRoot
+        }
+      };
+
+      process.Start();
+      Task<string> stdout = process.StandardOutput.ReadToEndAsync();
+      Task<string> stderr = process.StandardError.ReadToEndAsync();
+      await process.WaitForExitAsync();
+
+      string output = await stdout;
+      string error = await stderr;
+      Assert.Equal(0, process.ExitCode);
+      Assert.True(output.Contains("Reindex completed", StringComparison.OrdinalIgnoreCase) ||
+        error.Contains("Reindex completed", StringComparison.OrdinalIgnoreCase));
+    }
+    finally
+    {
+      if (Directory.Exists(workspace))
+      {
+        Directory.Delete(workspace, recursive: true);
+      }
+    }
+  }
+
+  [Fact]
+  public async Task DbfConvert_WritesToDirectoryWithDbfExtension()
+  {
+    string repoRoot = ToolTestContext.RepoRoot;
+    string toolAssembly = ToolTestContext.GetToolAssemblyPath();
+    Assert.True(File.Exists(toolAssembly));
+
+    string workspace = Path.Combine(Path.GetTempPath(), $"xbase-dbfconvert-{Guid.NewGuid():N}");
+    Directory.CreateDirectory(workspace);
+
+    try
+    {
+      string tablePath = DbfTestBuilder.CreateTable(
+        workspace,
+        "customers",
+        (false, "A001"),
+        (true, "A002"));
+      string outputDirectory = Path.Combine(workspace, "converted");
+
+      using var process = new Process
+      {
+        StartInfo = new ProcessStartInfo
+        {
+          FileName = "dotnet",
+          ArgumentList =
+          {
+            toolAssembly,
+            "dbfconvert",
+            tablePath,
+            "--output",
+            outputDirectory,
+            "--overwrite",
+            "--drop-deleted"
+          },
+          RedirectStandardOutput = true,
+          RedirectStandardError = true,
+          UseShellExecute = false,
+          WorkingDirectory = repoRoot
+        }
+      };
+
+      process.Start();
+      Task<string> stdout = process.StandardOutput.ReadToEndAsync();
+      Task<string> stderr = process.StandardError.ReadToEndAsync();
+      await process.WaitForExitAsync();
+
+      string output = await stdout;
+      string error = await stderr;
+      Assert.Equal(0, process.ExitCode);
+      Assert.True(output.Contains("Converted", StringComparison.OrdinalIgnoreCase) ||
+        error.Contains("Converted", StringComparison.OrdinalIgnoreCase));
+
+      string expectedPath = Path.Combine(outputDirectory, "customers.dbf");
+      Assert.True(File.Exists(expectedPath), $"Converted DBF was not written to {expectedPath}.");
+
+      var loader = new DbfTableLoader();
+      DbfTableDescriptor converted = loader.LoadDbf(expectedPath);
+      (uint total, uint deleted) = CountRecords(
+        expectedPath,
+        converted.HeaderLength,
+        converted.RecordLength);
+      Assert.Equal<uint>(0, deleted);
+      Assert.Equal<uint>(1, total);
+    }
+    finally
+    {
+      if (Directory.Exists(workspace))
+      {
+        Directory.Delete(workspace, recursive: true);
+      }
+    }
+  }
+
+  private static (uint total, uint deleted) CountRecords(string path, ushort headerLength, ushort recordLength)
+  {
+    using FileStream stream = new(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+    stream.Seek(headerLength, SeekOrigin.Begin);
+
+    if (recordLength == 0)
+    {
+      return (0, 0);
+    }
+
+    byte[] buffer = new byte[recordLength];
+    uint total = 0;
+    uint deleted = 0;
+
+    while (true)
+    {
+      int read = stream.Read(buffer, 0, buffer.Length);
+      if (read < buffer.Length)
+      {
+        break;
+      }
+
+      if (buffer[0] == 0x1A)
+      {
+        break;
+      }
+
+      total++;
+      if (buffer[0] == 0x2A || buffer[0] == (byte)'*')
+      {
+        deleted++;
+      }
+    }
+
+    return (total, deleted);
+  }
+}

--- a/tests/XBase.Tools.Tests/DdlCommandTests.cs
+++ b/tests/XBase.Tools.Tests/DdlCommandTests.cs
@@ -15,9 +15,8 @@ public sealed class DdlCommandTests
   [Fact]
   public async Task ApplyCommand_WritesSchemaLog()
   {
-    string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
-    string buildConfiguration = GetBuildConfiguration();
-    string toolAssembly = Path.Combine(repoRoot, "src", "XBase.Tools", "bin", buildConfiguration, "net8.0", "XBase.Tools.dll");
+    string repoRoot = ToolTestContext.RepoRoot;
+    string toolAssembly = ToolTestContext.GetToolAssemblyPath();
     Assert.True(File.Exists(toolAssembly));
     string workspace = Path.Combine(Path.GetTempPath(), $"xbase-ddl-{Guid.NewGuid():N}");
     Directory.CreateDirectory(workspace);
@@ -75,9 +74,8 @@ public sealed class DdlCommandTests
   [Fact]
   public async Task CheckpointDryRun_PrintsStatus()
   {
-    string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
-    string buildConfiguration = GetBuildConfiguration();
-    string toolAssembly = Path.Combine(repoRoot, "src", "XBase.Tools", "bin", buildConfiguration, "net8.0", "XBase.Tools.dll");
+    string repoRoot = ToolTestContext.RepoRoot;
+    string toolAssembly = ToolTestContext.GetToolAssemblyPath();
     Assert.True(File.Exists(toolAssembly));
     string workspace = Path.Combine(Path.GetTempPath(), $"xbase-ddl-{Guid.NewGuid():N}");
     Directory.CreateDirectory(workspace);
@@ -127,9 +125,8 @@ public sealed class DdlCommandTests
   [Fact]
   public async Task PackDryRun_PrintsStatus()
   {
-    string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
-    string buildConfiguration = GetBuildConfiguration();
-    string toolAssembly = Path.Combine(repoRoot, "src", "XBase.Tools", "bin", buildConfiguration, "net8.0", "XBase.Tools.dll");
+    string repoRoot = ToolTestContext.RepoRoot;
+    string toolAssembly = ToolTestContext.GetToolAssemblyPath();
     Assert.True(File.Exists(toolAssembly));
     string workspace = Path.Combine(Path.GetTempPath(), $"xbase-ddl-{Guid.NewGuid():N}");
     Directory.CreateDirectory(workspace);
@@ -183,9 +180,8 @@ public sealed class DdlCommandTests
   [Fact]
   public async Task PackCommand_RewritesDbfAndClearsQueue()
   {
-    string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
-    string buildConfiguration = GetBuildConfiguration();
-    string toolAssembly = Path.Combine(repoRoot, "src", "XBase.Tools", "bin", buildConfiguration, "net8.0", "XBase.Tools.dll");
+    string repoRoot = ToolTestContext.RepoRoot;
+    string toolAssembly = ToolTestContext.GetToolAssemblyPath();
     Assert.True(File.Exists(toolAssembly));
     string workspacePath = Path.Combine(Path.GetTempPath(), $"xbase-ddl-{Guid.NewGuid():N}");
     Directory.CreateDirectory(workspacePath);
@@ -264,9 +260,8 @@ public sealed class DdlCommandTests
   [Fact]
   public async Task ReindexCommand_RebuildsIndexes()
   {
-    string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
-    string buildConfiguration = GetBuildConfiguration();
-    string toolAssembly = Path.Combine(repoRoot, "src", "XBase.Tools", "bin", buildConfiguration, "net8.0", "XBase.Tools.dll");
+    string repoRoot = ToolTestContext.RepoRoot;
+    string toolAssembly = ToolTestContext.GetToolAssemblyPath();
     Assert.True(File.Exists(toolAssembly));
     string workspacePath = Path.Combine(Path.GetTempPath(), $"xbase-ddl-{Guid.NewGuid():N}");
     Directory.CreateDirectory(workspacePath);
@@ -323,16 +318,4 @@ public sealed class DdlCommandTests
     }
   }
 
-  private static string GetBuildConfiguration()
-  {
-    var baseDirectory = new DirectoryInfo(AppContext.BaseDirectory);
-    string? configuration = baseDirectory.Parent?.Name;
-
-    if (string.IsNullOrEmpty(configuration))
-    {
-      throw new InvalidOperationException("Unable to determine build configuration for test execution.");
-    }
-
-    return configuration;
-  }
 }

--- a/tests/XBase.Tools.Tests/ToolTestContext.cs
+++ b/tests/XBase.Tools.Tests/ToolTestContext.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+
+namespace XBase.Tools.Tests;
+
+internal static class ToolTestContext
+{
+  public static string RepoRoot { get; } =
+    Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
+
+  public static string BuildConfiguration
+  {
+    get
+    {
+      var baseDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+      string? configuration = baseDirectory.Parent?.Name;
+      if (string.IsNullOrEmpty(configuration))
+      {
+        throw new InvalidOperationException("Unable to determine build configuration for test execution.");
+      }
+
+      return configuration;
+    }
+  }
+
+  public static string GetToolAssemblyPath()
+  {
+    string toolAssembly = Path.Combine(
+      RepoRoot,
+      "src",
+      "XBase.Tools",
+      "bin",
+      BuildConfiguration,
+      "net8.0",
+      "XBase.Tools.dll");
+
+    return toolAssembly;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable DBF column factory and wire SqlTableResolver to consume it
- extend the encoding registry and dbfconvert defaults to emit .dbf output consistently
- introduce CLI smoke tests with supporting test context and refresh the task tracker

## Testing
- dotnet test xBase.sln --configuration Release --filter 'FullyQualifiedName!~XBase.Tools.Tests'
- dotnet test tests/XBase.Tools.Tests/XBase.Tools.Tests.csproj --configuration Release --filter DbfCommandTests.Dbfdump_WritesCsvToDirectory
- dotnet test tests/XBase.Tools.Tests/XBase.Tools.Tests.csproj --configuration Release --filter DbfCommandTests.DbfPack_RemovesDeletedRecords
- dotnet test tests/XBase.Tools.Tests/XBase.Tools.Tests.csproj --configuration Release --filter DbfCommandTests.DbfReindex_SucceedsWithoutIndexes
- dotnet test tests/XBase.Tools.Tests/XBase.Tools.Tests.csproj --configuration Release --filter DbfCommandTests.DbfConvert_WritesToDirectoryWithDbfExtension

------
https://chatgpt.com/codex/tasks/task_e_68dd5f2a5a54832294a8c79f9d709059

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved DBF column parsing and value extraction for broader field types and encodings.
  - Changed default output filename for conversions to use .dbf (was .utf8.dbf).
- Refactor
  - Centralized column creation logic across providers for consistent behavior.
- Tests
  - Added end-to-end CLI tests covering dump, pack, reindex, and convert commands.
- Chores
  - Updated project task statuses and milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->