### PR TITLE
feat(demo): add ddl and index management workflows

### DIFF
--- a/src/demo/XBase.Demo.App/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/demo/XBase.Demo.App/DependencyInjection/ServiceCollectionExtensions.cs
@@ -16,6 +16,8 @@ public static class ServiceCollectionExtensions
     services.AddXBaseDemoInfrastructure();
     services.AddXBaseDemoDiagnostics();
 
+    services.AddSingleton<SchemaDesignerViewModel>();
+    services.AddSingleton<IndexManagerViewModel>();
     services.AddSingleton<ShellViewModel>();
     services.AddSingleton<MainWindow>();
 

--- a/src/demo/XBase.Demo.App/ViewModels/IndexManagerViewModel.cs
+++ b/src/demo/XBase.Demo.App/ViewModels/IndexManagerViewModel.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using ReactiveUI;
+using XBase.Demo.Domain.Services;
+using XBase.Demo.Domain.Services.Models;
+
+namespace XBase.Demo.App.ViewModels;
+
+/// <summary>
+/// Handles index create/drop operations for the selected table.
+/// </summary>
+public sealed class IndexManagerViewModel : ReactiveObject
+{
+  private readonly IIndexManagementService _indexService;
+  private TableListItemViewModel? _table;
+  private string? _indexName;
+  private string? _indexExpression;
+  private string? _statusMessage;
+  private string? _errorMessage;
+  private bool _isBusy;
+
+  public IndexManagerViewModel(IIndexManagementService indexService)
+  {
+    _indexService = indexService;
+
+    CreateIndexCommand = ReactiveCommand.CreateFromTask(ExecuteCreateIndexAsync);
+    CreateIndexCommand.Subscribe(ApplyResult);
+    CreateIndexCommand.ThrownExceptions.Subscribe(OnFault);
+
+    DropIndexCommand = ReactiveCommand.CreateFromTask<IndexListItemViewModel, IndexOperationResult>(ExecuteDropIndexAsync);
+    DropIndexCommand.Subscribe(ApplyResult);
+    DropIndexCommand.ThrownExceptions.Subscribe(OnFault);
+
+    Observable.Merge(
+            CreateIndexCommand.IsExecuting,
+            DropIndexCommand.IsExecuting)
+        .Subscribe(isExecuting => IsBusy = isExecuting);
+  }
+
+  public ReactiveCommand<Unit, IndexOperationResult> CreateIndexCommand { get; }
+
+  public ReactiveCommand<IndexListItemViewModel, IndexOperationResult> DropIndexCommand { get; }
+
+  public bool IsBusy
+  {
+    get => _isBusy;
+    private set => this.RaiseAndSetIfChanged(ref _isBusy, value);
+  }
+
+  public string? IndexName
+  {
+    get => _indexName;
+    set => this.RaiseAndSetIfChanged(ref _indexName, value);
+  }
+
+  public string? IndexExpression
+  {
+    get => _indexExpression;
+    set => this.RaiseAndSetIfChanged(ref _indexExpression, value);
+  }
+
+  public string? StatusMessage
+  {
+    get => _statusMessage;
+    private set => this.RaiseAndSetIfChanged(ref _statusMessage, value);
+  }
+
+  public string? ErrorMessage
+  {
+    get => _errorMessage;
+    private set => this.RaiseAndSetIfChanged(ref _errorMessage, value);
+  }
+
+  public void SetTargetTable(TableListItemViewModel? table)
+  {
+    _table = table;
+    StatusMessage = null;
+    ErrorMessage = null;
+    if (table is null)
+    {
+      IndexName = null;
+      IndexExpression = null;
+    }
+  }
+
+  private async Task<IndexOperationResult> ExecuteCreateIndexAsync()
+  {
+    if (_table is null)
+    {
+      throw new InvalidOperationException("Select a table before creating an index.");
+    }
+
+    if (string.IsNullOrWhiteSpace(IndexName) || string.IsNullOrWhiteSpace(IndexExpression))
+    {
+      throw new InvalidOperationException("Index name and expression are required.");
+    }
+
+    var request = IndexCreateRequest.Create(_table.Model.Path, IndexName!, IndexExpression!);
+    return await _indexService.CreateIndexAsync(request);
+  }
+
+  private async Task<IndexOperationResult> ExecuteDropIndexAsync(IndexListItemViewModel index)
+  {
+    ArgumentNullException.ThrowIfNull(index);
+    if (_table is null)
+    {
+      throw new InvalidOperationException("Select a table before dropping an index.");
+    }
+
+    var request = IndexDropRequest.Create(_table.Model.Path, index.Name);
+    return await _indexService.DropIndexAsync(request);
+  }
+
+  private void ApplyResult(IndexOperationResult result)
+  {
+    if (result.Succeeded)
+    {
+      StatusMessage = result.Message;
+      ErrorMessage = null;
+    }
+    else
+    {
+      StatusMessage = null;
+      ErrorMessage = result.Message;
+    }
+  }
+
+  private void OnFault(Exception exception)
+  {
+    StatusMessage = null;
+    ErrorMessage = exception.Message;
+  }
+}

--- a/src/demo/XBase.Demo.App/ViewModels/SchemaColumnChangeViewModel.cs
+++ b/src/demo/XBase.Demo.App/ViewModels/SchemaColumnChangeViewModel.cs
@@ -1,0 +1,33 @@
+using System;
+using XBase.Demo.Domain.Schema;
+
+namespace XBase.Demo.App.ViewModels;
+
+/// <summary>
+/// Represents an alteration action for schema preview generation.
+/// </summary>
+public sealed class SchemaColumnChangeViewModel
+{
+  public SchemaColumnChangeViewModel(
+      ColumnChangeOperation operation,
+      string columnName,
+      SchemaColumnViewModel? columnDefinition = null,
+      string? newColumnName = null)
+  {
+    Operation = operation;
+    ColumnName = columnName ?? throw new ArgumentNullException(nameof(columnName));
+    ColumnDefinition = columnDefinition;
+    NewColumnName = newColumnName;
+  }
+
+  public ColumnChangeOperation Operation { get; }
+
+  public string ColumnName { get; }
+
+  public SchemaColumnViewModel? ColumnDefinition { get; }
+
+  public string? NewColumnName { get; }
+
+  public ColumnChangeDefinition ToDefinition()
+      => new(Operation, ColumnName, ColumnDefinition?.ToDefinition(), NewColumnName);
+}

--- a/src/demo/XBase.Demo.App/ViewModels/SchemaColumnViewModel.cs
+++ b/src/demo/XBase.Demo.App/ViewModels/SchemaColumnViewModel.cs
@@ -1,0 +1,42 @@
+using System;
+using XBase.Demo.Domain.Schema;
+
+namespace XBase.Demo.App.ViewModels;
+
+/// <summary>
+/// Represents a column definition used by the schema designer.
+/// </summary>
+public sealed class SchemaColumnViewModel
+{
+  public SchemaColumnViewModel(string name, string dataType, bool allowNulls = true, int? length = null, int? scale = null)
+  {
+    if (string.IsNullOrWhiteSpace(name))
+    {
+      throw new ArgumentException("Column name is required.", nameof(name));
+    }
+
+    if (string.IsNullOrWhiteSpace(dataType))
+    {
+      throw new ArgumentException("Column data type is required.", nameof(dataType));
+    }
+
+    Name = name;
+    DataType = dataType;
+    AllowNulls = allowNulls;
+    Length = length;
+    Scale = scale;
+  }
+
+  public string Name { get; }
+
+  public string DataType { get; }
+
+  public bool AllowNulls { get; }
+
+  public int? Length { get; }
+
+  public int? Scale { get; }
+
+  public TableColumnDefinition ToDefinition()
+      => new(Name, DataType, AllowNulls, Length, Scale);
+}

--- a/src/demo/XBase.Demo.App/ViewModels/SchemaDesignerViewModel.cs
+++ b/src/demo/XBase.Demo.App/ViewModels/SchemaDesignerViewModel.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reactive;
+using System.Threading.Tasks;
+using ReactiveUI;
+using XBase.Demo.Domain.Schema;
+using XBase.Demo.Domain.Services;
+
+namespace XBase.Demo.App.ViewModels;
+
+/// <summary>
+/// Provides commands for generating schema DDL previews.
+/// </summary>
+public sealed class SchemaDesignerViewModel : ReactiveObject
+{
+  private readonly ISchemaDdlService _ddlService;
+  private readonly ObservableCollection<SchemaColumnViewModel> _columns = new();
+  private readonly ObservableCollection<SchemaColumnChangeViewModel> _alterations = new();
+  private string? _tableName;
+  private string? _previewOperation;
+  private string _previewUpScript = string.Empty;
+  private string _previewDownScript = string.Empty;
+  private string? _errorMessage;
+
+  public SchemaDesignerViewModel(ISchemaDdlService ddlService)
+  {
+    _ddlService = ddlService;
+
+    Columns = new ReadOnlyObservableCollection<SchemaColumnViewModel>(_columns);
+    Alterations = new ReadOnlyObservableCollection<SchemaColumnChangeViewModel>(_alterations);
+
+    GenerateCreatePreviewCommand = ReactiveCommand.CreateFromTask(ExecuteGenerateCreatePreviewAsync);
+    GenerateCreatePreviewCommand.Subscribe(ApplyPreview);
+    GenerateCreatePreviewCommand.ThrownExceptions.Subscribe(OnPreviewFault);
+
+    GenerateAlterPreviewCommand = ReactiveCommand.CreateFromTask(ExecuteGenerateAlterPreviewAsync);
+    GenerateAlterPreviewCommand.Subscribe(ApplyPreview);
+    GenerateAlterPreviewCommand.ThrownExceptions.Subscribe(OnPreviewFault);
+
+    GenerateDropPreviewCommand = ReactiveCommand.CreateFromTask(ExecuteGenerateDropPreviewAsync);
+    GenerateDropPreviewCommand.Subscribe(ApplyPreview);
+    GenerateDropPreviewCommand.ThrownExceptions.Subscribe(OnPreviewFault);
+  }
+
+  public ReadOnlyObservableCollection<SchemaColumnViewModel> Columns { get; }
+
+  public ReadOnlyObservableCollection<SchemaColumnChangeViewModel> Alterations { get; }
+
+  public ReactiveCommand<Unit, DdlPreview> GenerateCreatePreviewCommand { get; }
+
+  public ReactiveCommand<Unit, DdlPreview> GenerateAlterPreviewCommand { get; }
+
+  public ReactiveCommand<Unit, DdlPreview> GenerateDropPreviewCommand { get; }
+
+  public string? TableName
+  {
+    get => _tableName;
+    set => this.RaiseAndSetIfChanged(ref _tableName, value);
+  }
+
+  public string? PreviewOperation
+  {
+    get => _previewOperation;
+    private set => this.RaiseAndSetIfChanged(ref _previewOperation, value);
+  }
+
+  public string PreviewUpScript
+  {
+    get => _previewUpScript;
+    private set => this.RaiseAndSetIfChanged(ref _previewUpScript, value);
+  }
+
+  public string PreviewDownScript
+  {
+    get => _previewDownScript;
+    private set => this.RaiseAndSetIfChanged(ref _previewDownScript, value);
+  }
+
+  public string? ErrorMessage
+  {
+    get => _errorMessage;
+    private set => this.RaiseAndSetIfChanged(ref _errorMessage, value);
+  }
+
+  public void SetTargetTable(TableListItemViewModel? table)
+  {
+    TableName = table?.Name;
+    ErrorMessage = null;
+  }
+
+  public void SetColumns(params SchemaColumnViewModel[] columns)
+  {
+    _columns.Clear();
+    foreach (var column in columns)
+    {
+      _columns.Add(column);
+    }
+  }
+
+  public void SetAlterations(params SchemaColumnChangeViewModel[] alterations)
+  {
+    _alterations.Clear();
+    foreach (var alteration in alterations)
+    {
+      _alterations.Add(alteration);
+    }
+  }
+
+  private async Task<DdlPreview> ExecuteGenerateCreatePreviewAsync()
+  {
+    if (string.IsNullOrWhiteSpace(TableName))
+    {
+      throw new InvalidOperationException("Table name is required to generate DDL.");
+    }
+
+    if (_columns.Count == 0)
+    {
+      throw new InvalidOperationException("At least one column is required to generate a CREATE TABLE script.");
+    }
+
+    var schema = new TableSchemaDefinition(TableName!, _columns.Select(column => column.ToDefinition()).ToArray());
+    var preview = await _ddlService.BuildCreateTablePreviewAsync(schema);
+    return preview;
+  }
+
+  private async Task<DdlPreview> ExecuteGenerateAlterPreviewAsync()
+  {
+    if (string.IsNullOrWhiteSpace(TableName))
+    {
+      throw new InvalidOperationException("Table name is required to generate DDL.");
+    }
+
+    if (_alterations.Count == 0)
+    {
+      throw new InvalidOperationException("At least one alteration is required to generate an ALTER TABLE script.");
+    }
+
+    var definition = new TableAlterationDefinition(TableName!, _alterations.Select(change => change.ToDefinition()).ToArray());
+    return await _ddlService.BuildAlterTablePreviewAsync(definition);
+  }
+
+  private async Task<DdlPreview> ExecuteGenerateDropPreviewAsync()
+  {
+    if (string.IsNullOrWhiteSpace(TableName))
+    {
+      throw new InvalidOperationException("Table name is required to generate DDL.");
+    }
+
+    return await _ddlService.BuildDropTablePreviewAsync(TableName!);
+  }
+
+  private void ApplyPreview(DdlPreview preview)
+  {
+    PreviewOperation = preview.Operation;
+    PreviewUpScript = string.Join(Environment.NewLine + Environment.NewLine, preview.UpStatements);
+    PreviewDownScript = string.Join(Environment.NewLine + Environment.NewLine, preview.DownStatements);
+    ErrorMessage = null;
+  }
+
+  private void OnPreviewFault(Exception exception)
+  {
+    ErrorMessage = exception.Message;
+  }
+}

--- a/src/demo/XBase.Demo.Domain/Schema/DdlPreview.cs
+++ b/src/demo/XBase.Demo.Domain/Schema/DdlPreview.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+
+namespace XBase.Demo.Domain.Schema;
+
+/// <summary>
+/// Represents a set of statements generated for a schema operation preview.
+/// </summary>
+/// <param name="Operation">Logical operation identifier (e.g. CreateTable, AlterTable).</param>
+/// <param name="UpStatements">Statements executed to apply the change.</param>
+/// <param name="DownStatements">Statements that undo the change, when available.</param>
+public sealed record DdlPreview(string Operation, IReadOnlyList<string> UpStatements, IReadOnlyList<string> DownStatements)
+{
+  public static DdlPreview Empty(string operation)
+      => new(operation, Array.Empty<string>(), Array.Empty<string>());
+}

--- a/src/demo/XBase.Demo.Domain/Schema/TableSchemaDefinition.cs
+++ b/src/demo/XBase.Demo.Domain/Schema/TableSchemaDefinition.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+
+namespace XBase.Demo.Domain.Schema;
+
+/// <summary>
+/// Describes a table schema used when generating create/alter previews.
+/// </summary>
+/// <param name="TableName">Logical table name.</param>
+/// <param name="Columns">Ordered column definitions.</param>
+public sealed record TableSchemaDefinition(string TableName, IReadOnlyList<TableColumnDefinition> Columns);
+
+/// <summary>
+/// Describes a single column participating in schema operations.
+/// </summary>
+/// <param name="Name">Column name.</param>
+/// <param name="DataType">Provider-specific data type token.</param>
+/// <param name="AllowNulls">Indicates whether NULL values are permitted.</param>
+/// <param name="Length">Optional data type length.</param>
+/// <param name="Scale">Optional data type scale.</param>
+public sealed record TableColumnDefinition(string Name, string DataType, bool AllowNulls = true, int? Length = null, int? Scale = null);
+
+/// <summary>
+/// Enumerates supported column change operations for ALTER TABLE previews.
+/// </summary>
+public enum ColumnChangeOperation
+{
+  Add,
+  Alter,
+  Drop,
+  Rename
+}
+
+/// <summary>
+/// Describes a column-level change used when building ALTER TABLE previews.
+/// </summary>
+/// <param name="Operation">Type of change to apply.</param>
+/// <param name="ColumnName">Name of the target column.</param>
+/// <param name="ColumnDefinition">Optional column definition used for add/alter/drop rollback scripts.</param>
+/// <param name="NewColumnName">Optional new column name when renaming.</param>
+public sealed record ColumnChangeDefinition(
+    ColumnChangeOperation Operation,
+    string ColumnName,
+    TableColumnDefinition? ColumnDefinition = null,
+    string? NewColumnName = null);
+
+/// <summary>
+/// Represents a collection of column changes for an ALTER TABLE preview.
+/// </summary>
+/// <param name="TableName">Target table name.</param>
+/// <param name="ColumnChanges">Ordered column change operations.</param>
+public sealed record TableAlterationDefinition(string TableName, IReadOnlyList<ColumnChangeDefinition> ColumnChanges);

--- a/src/demo/XBase.Demo.Domain/Services/IIndexManagementService.cs
+++ b/src/demo/XBase.Demo.Domain/Services/IIndexManagementService.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using XBase.Demo.Domain.Services.Models;
+
+namespace XBase.Demo.Domain.Services;
+
+/// <summary>
+/// Provides index lifecycle management for demo scenarios.
+/// </summary>
+public interface IIndexManagementService
+{
+  Task<IndexOperationResult> CreateIndexAsync(IndexCreateRequest request, CancellationToken cancellationToken = default);
+
+  Task<IndexOperationResult> DropIndexAsync(IndexDropRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/demo/XBase.Demo.Domain/Services/ISchemaDdlService.cs
+++ b/src/demo/XBase.Demo.Domain/Services/ISchemaDdlService.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+using XBase.Demo.Domain.Schema;
+
+namespace XBase.Demo.Domain.Services;
+
+/// <summary>
+/// Provides provider-aware schema DDL preview generation for create/alter/drop operations.
+/// </summary>
+public interface ISchemaDdlService
+{
+  Task<DdlPreview> BuildCreateTablePreviewAsync(TableSchemaDefinition schema, CancellationToken cancellationToken = default);
+
+  Task<DdlPreview> BuildAlterTablePreviewAsync(TableAlterationDefinition alteration, CancellationToken cancellationToken = default);
+
+  Task<DdlPreview> BuildDropTablePreviewAsync(string tableName, CancellationToken cancellationToken = default);
+}

--- a/src/demo/XBase.Demo.Domain/Services/Models/IndexRequests.cs
+++ b/src/demo/XBase.Demo.Domain/Services/Models/IndexRequests.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace XBase.Demo.Domain.Services.Models;
+
+/// <summary>
+/// Describes the inputs required to create an index in the demo catalog.
+/// </summary>
+/// <param name="TablePath">Absolute path to the table (DBF) file.</param>
+/// <param name="IndexName">Logical index name including extension.</param>
+/// <param name="Expression">Index key expression.</param>
+public sealed record IndexCreateRequest(string TablePath, string IndexName, string Expression)
+{
+  public static IndexCreateRequest Create(string tablePath, string indexName, string expression)
+  {
+    ArgumentException.ThrowIfNullOrWhiteSpace(tablePath);
+    ArgumentException.ThrowIfNullOrWhiteSpace(indexName);
+    ArgumentException.ThrowIfNullOrWhiteSpace(expression);
+    return new IndexCreateRequest(tablePath, indexName, expression);
+  }
+}
+
+/// <summary>
+/// Describes the inputs required to drop an index from the demo catalog.
+/// </summary>
+/// <param name="TablePath">Absolute path to the table (DBF) file.</param>
+/// <param name="IndexName">Logical index name including extension.</param>
+public sealed record IndexDropRequest(string TablePath, string IndexName)
+{
+  public static IndexDropRequest Create(string tablePath, string indexName)
+  {
+    ArgumentException.ThrowIfNullOrWhiteSpace(tablePath);
+    ArgumentException.ThrowIfNullOrWhiteSpace(indexName);
+    return new IndexDropRequest(tablePath, indexName);
+  }
+}
+
+/// <summary>
+/// Represents the result of an index lifecycle operation.
+/// </summary>
+/// <param name="Succeeded">Indicates whether the operation completed successfully.</param>
+/// <param name="Message">Human-readable status message.</param>
+/// <param name="Exception">Optional exception surfaced by the operation.</param>
+public sealed record IndexOperationResult(bool Succeeded, string Message, Exception? Exception = null)
+{
+  public static IndexOperationResult Success(string message)
+      => new(true, message, null);
+
+  public static IndexOperationResult Failure(string message, Exception? exception = null)
+      => new(false, message, exception);
+};

--- a/src/demo/XBase.Demo.Infrastructure/Indexes/FileSystemIndexManagementService.cs
+++ b/src/demo/XBase.Demo.Infrastructure/Indexes/FileSystemIndexManagementService.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using XBase.Demo.Domain.Services;
+using XBase.Demo.Domain.Services.Models;
+
+namespace XBase.Demo.Infrastructure.Indexes;
+
+/// <summary>
+/// Minimal index lifecycle service that creates placeholder index files on disk.
+/// </summary>
+public sealed class FileSystemIndexManagementService : IIndexManagementService
+{
+  private readonly ILogger<FileSystemIndexManagementService> _logger;
+
+  public FileSystemIndexManagementService(ILogger<FileSystemIndexManagementService> logger)
+  {
+    _logger = logger;
+  }
+
+  public async Task<IndexOperationResult> CreateIndexAsync(IndexCreateRequest request, CancellationToken cancellationToken = default)
+  {
+    ArgumentNullException.ThrowIfNull(request);
+    cancellationToken.ThrowIfCancellationRequested();
+
+    try
+    {
+      var tableDirectory = ResolveTableDirectory(request.TablePath);
+      var indexPath = Path.Combine(tableDirectory, request.IndexName);
+      if (File.Exists(indexPath))
+      {
+        return IndexOperationResult.Failure($"Index '{request.IndexName}' already exists.");
+      }
+
+      Directory.CreateDirectory(tableDirectory);
+      await using var stream = new FileStream(indexPath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+      var content = Encoding.UTF8.GetBytes($"// Placeholder index for expression: {request.Expression}{Environment.NewLine}");
+      await stream.WriteAsync(content, 0, content.Length, cancellationToken);
+      await stream.FlushAsync(cancellationToken);
+
+      _logger.LogInformation("Created index placeholder {Index} for table {Table}", indexPath, request.TablePath);
+      return IndexOperationResult.Success($"Index '{request.IndexName}' created successfully.");
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to create index {Index} for table {Table}", request.IndexName, request.TablePath);
+      return IndexOperationResult.Failure($"Failed to create index '{request.IndexName}'. {ex.Message}", ex);
+    }
+  }
+
+  public Task<IndexOperationResult> DropIndexAsync(IndexDropRequest request, CancellationToken cancellationToken = default)
+  {
+    ArgumentNullException.ThrowIfNull(request);
+    cancellationToken.ThrowIfCancellationRequested();
+
+    try
+    {
+      var tableDirectory = ResolveTableDirectory(request.TablePath);
+      var indexPath = Path.Combine(tableDirectory, request.IndexName);
+      if (!File.Exists(indexPath))
+      {
+        return Task.FromResult(IndexOperationResult.Failure($"Index '{request.IndexName}' was not found."));
+      }
+
+      File.Delete(indexPath);
+      _logger.LogInformation("Dropped index placeholder {Index} for table {Table}", indexPath, request.TablePath);
+      return Task.FromResult(IndexOperationResult.Success($"Index '{request.IndexName}' dropped successfully."));
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Failed to drop index {Index} for table {Table}", request.IndexName, request.TablePath);
+      return Task.FromResult(IndexOperationResult.Failure($"Failed to drop index '{request.IndexName}'. {ex.Message}", ex));
+    }
+  }
+
+  private static string ResolveTableDirectory(string tablePath)
+  {
+    ArgumentException.ThrowIfNullOrWhiteSpace(tablePath);
+    var tableDirectory = Path.GetDirectoryName(tablePath);
+    if (string.IsNullOrWhiteSpace(tableDirectory))
+    {
+      throw new DirectoryNotFoundException($"Unable to resolve directory for table path '{tablePath}'.");
+    }
+
+    return tableDirectory;
+  }
+}

--- a/src/demo/XBase.Demo.Infrastructure/Schema/TemplateSchemaDdlService.cs
+++ b/src/demo/XBase.Demo.Infrastructure/Schema/TemplateSchemaDdlService.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using XBase.Demo.Domain.Schema;
+using XBase.Demo.Domain.Services;
+
+namespace XBase.Demo.Infrastructure.Schema;
+
+/// <summary>
+/// Lightweight DDL generator that emits provider-neutral scripts suitable for previews.
+/// </summary>
+public sealed class TemplateSchemaDdlService : ISchemaDdlService
+{
+  private readonly ILogger<TemplateSchemaDdlService> _logger;
+
+  public TemplateSchemaDdlService(ILogger<TemplateSchemaDdlService> logger)
+  {
+    _logger = logger;
+  }
+
+  public Task<DdlPreview> BuildCreateTablePreviewAsync(TableSchemaDefinition schema, CancellationToken cancellationToken = default)
+  {
+    ArgumentNullException.ThrowIfNull(schema);
+    cancellationToken.ThrowIfCancellationRequested();
+
+    EnsureValidIdentifier(schema.TableName, nameof(schema.TableName));
+    if (schema.Columns.Count == 0)
+    {
+      throw new InvalidOperationException("At least one column is required to build a CREATE TABLE script.");
+    }
+
+    var builder = new StringBuilder();
+    builder.AppendLine($"CREATE TABLE {schema.TableName} (");
+    for (var i = 0; i < schema.Columns.Count; i++)
+    {
+      var column = schema.Columns[i];
+      var line = FormatColumnDefinition(column);
+      builder.Append("  ");
+      builder.Append(line);
+      if (i < schema.Columns.Count - 1)
+      {
+        builder.Append(',');
+      }
+
+      builder.AppendLine();
+    }
+
+    builder.AppendLine(");");
+
+    var downStatements = new List<string>
+    {
+      $"DROP TABLE {schema.TableName};"
+    };
+
+    var preview = new DdlPreview("CreateTable", new[] { builder.ToString().TrimEnd() }, downStatements);
+    _logger.LogInformation("Generated CREATE TABLE preview for {Table}", schema.TableName);
+    return Task.FromResult(preview);
+  }
+
+  public Task<DdlPreview> BuildAlterTablePreviewAsync(TableAlterationDefinition alteration, CancellationToken cancellationToken = default)
+  {
+    ArgumentNullException.ThrowIfNull(alteration);
+    cancellationToken.ThrowIfCancellationRequested();
+
+    EnsureValidIdentifier(alteration.TableName, nameof(alteration.TableName));
+    if (alteration.ColumnChanges.Count == 0)
+    {
+      throw new InvalidOperationException("At least one column change is required to build an ALTER TABLE script.");
+    }
+
+    var upStatements = new List<string>();
+    var downStatements = new List<string>();
+
+    foreach (var change in alteration.ColumnChanges)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+      upStatements.Add(BuildAlterStatement(alteration.TableName, change));
+      downStatements.Insert(0, BuildRollbackStatement(alteration.TableName, change));
+    }
+
+    var preview = new DdlPreview("AlterTable", upStatements, downStatements);
+    _logger.LogInformation("Generated ALTER TABLE preview for {Table} with {ChangeCount} changes", alteration.TableName, alteration.ColumnChanges.Count);
+    return Task.FromResult(preview);
+  }
+
+  public Task<DdlPreview> BuildDropTablePreviewAsync(string tableName, CancellationToken cancellationToken = default)
+  {
+    ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+    cancellationToken.ThrowIfCancellationRequested();
+
+    var statements = new[] { $"DROP TABLE {tableName};" };
+    var rollback = new[] { $"-- Recreate table {tableName} using the captured CREATE script." };
+    var preview = new DdlPreview("DropTable", statements, rollback);
+    _logger.LogInformation("Generated DROP TABLE preview for {Table}", tableName);
+    return Task.FromResult(preview);
+  }
+
+  private static string FormatColumnDefinition(TableColumnDefinition column)
+  {
+    ArgumentNullException.ThrowIfNull(column);
+    EnsureValidIdentifier(column.Name, nameof(column.Name));
+    ArgumentException.ThrowIfNullOrWhiteSpace(column.DataType);
+
+    var typeToken = column.DataType.ToUpperInvariant();
+    if (column.Length.HasValue)
+    {
+      typeToken += column.Scale.HasValue
+          ? $"({column.Length.Value.ToString(CultureInfo.InvariantCulture)},{column.Scale.Value.ToString(CultureInfo.InvariantCulture)})"
+          : $"({column.Length.Value.ToString(CultureInfo.InvariantCulture)})";
+    }
+
+    var nullability = column.AllowNulls ? "NULL" : "NOT NULL";
+    return $"{column.Name} {typeToken} {nullability}";
+  }
+
+  private static string BuildAlterStatement(string tableName, ColumnChangeDefinition change)
+  {
+    return change.Operation switch
+    {
+      ColumnChangeOperation.Add => BuildAddColumnStatement(tableName, change),
+      ColumnChangeOperation.Alter => BuildAlterColumnStatement(tableName, change),
+      ColumnChangeOperation.Drop => BuildDropColumnStatement(tableName, change),
+      ColumnChangeOperation.Rename => BuildRenameColumnStatement(tableName, change),
+      _ => throw new ArgumentOutOfRangeException(nameof(change.Operation), change.Operation, "Unsupported column change operation.")
+    };
+  }
+
+  private static string BuildRollbackStatement(string tableName, ColumnChangeDefinition change)
+  {
+    return change.Operation switch
+    {
+      ColumnChangeOperation.Add => $"ALTER TABLE {tableName} DROP COLUMN {change.ColumnName};",
+      ColumnChangeOperation.Alter => $"-- Review manual rollback for column {change.ColumnName}.",
+      ColumnChangeOperation.Drop => change.ColumnDefinition is not null
+          ? $"ALTER TABLE {tableName} ADD COLUMN {FormatColumnDefinition(change.ColumnDefinition)};"
+          : $"-- Unable to restore dropped column {change.ColumnName} without definition.",
+      ColumnChangeOperation.Rename => change.NewColumnName is not null
+          ? $"ALTER TABLE {tableName} RENAME COLUMN {change.NewColumnName} TO {change.ColumnName};"
+          : $"-- Rename rollback unavailable for column {change.ColumnName}.",
+      _ => throw new ArgumentOutOfRangeException(nameof(change.Operation), change.Operation, "Unsupported column change operation.")
+    };
+  }
+
+  private static string BuildAddColumnStatement(string tableName, ColumnChangeDefinition change)
+  {
+    if (change.ColumnDefinition is null)
+    {
+      throw new InvalidOperationException($"Column definition is required when adding column '{change.ColumnName}'.");
+    }
+
+    return $"ALTER TABLE {tableName} ADD COLUMN {FormatColumnDefinition(change.ColumnDefinition)};";
+  }
+
+  private static string BuildAlterColumnStatement(string tableName, ColumnChangeDefinition change)
+  {
+    if (change.ColumnDefinition is null)
+    {
+      throw new InvalidOperationException($"Column definition is required when altering column '{change.ColumnName}'.");
+    }
+
+    return $"ALTER TABLE {tableName} ALTER COLUMN {FormatColumnDefinition(change.ColumnDefinition)};";
+  }
+
+  private static string BuildDropColumnStatement(string tableName, ColumnChangeDefinition change)
+  {
+    EnsureValidIdentifier(change.ColumnName, nameof(change.ColumnName));
+    return $"ALTER TABLE {tableName} DROP COLUMN {change.ColumnName};";
+  }
+
+  private static string BuildRenameColumnStatement(string tableName, ColumnChangeDefinition change)
+  {
+    EnsureValidIdentifier(change.ColumnName, nameof(change.ColumnName));
+    ArgumentException.ThrowIfNullOrWhiteSpace(change.NewColumnName);
+    EnsureValidIdentifier(change.NewColumnName!, nameof(change.NewColumnName));
+    return $"ALTER TABLE {tableName} RENAME COLUMN {change.ColumnName} TO {change.NewColumnName};";
+  }
+
+  private static void EnsureValidIdentifier(string identifier, string paramName)
+  {
+    ArgumentException.ThrowIfNullOrWhiteSpace(identifier, paramName);
+    if (identifier.Any(char.IsWhiteSpace))
+    {
+      throw new ArgumentException($"Identifier '{identifier}' cannot contain whitespace.", paramName);
+    }
+  }
+}

--- a/src/demo/XBase.Demo.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/demo/XBase.Demo.Infrastructure/ServiceCollectionExtensions.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using XBase.Demo.Domain.Services;
 using XBase.Demo.Infrastructure.Catalog;
+using XBase.Demo.Infrastructure.Indexes;
+using XBase.Demo.Infrastructure.Schema;
 
 namespace XBase.Demo.Infrastructure;
 
@@ -21,6 +23,8 @@ public static class ServiceCollectionExtensions
     services.AddLogging(builder => builder.AddDebug());
     services.AddSingleton<ITableCatalogService, FileSystemTableCatalogService>();
     services.AddSingleton<ITablePageService, NullTablePageService>();
+    services.AddSingleton<ISchemaDdlService, TemplateSchemaDdlService>();
+    services.AddSingleton<IIndexManagementService, FileSystemIndexManagementService>();
 
     return services;
   }

--- a/src/demo/tasks.md
+++ b/src/demo/tasks.md
@@ -10,9 +10,9 @@ Source blueprint: [docs/demo/avalonia-reactiveui-demo-plan.md](../../docs/demo/a
 - [x] Add integration smoke harness once basic navigation is ready.
 
 ## Milestone M2 – DDL & Index Basics
-- [ ] Generate DDL preview scripts for create/alter/drop operations.
-- [ ] Implement index create/drop services with error surfacing.
-- [ ] Extend ViewModels with command handlers for schema updates.
+- [x] Generate DDL preview scripts for create/alter/drop operations.
+- [x] Implement index create/drop services with error surfacing.
+- [x] Extend ViewModels with command handlers for schema updates.
 
 ## Milestone M3 – Rebuild & Diagnostics
 - [ ] Add side-by-side index rebuild orchestration with progress observables.

--- a/tests/XBase.Demo.App.Tests/DemoHostFactory.cs
+++ b/tests/XBase.Demo.App.Tests/DemoHostFactory.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using XBase.Demo.App.DependencyInjection;
+
+namespace XBase.Demo.App.Tests;
+
+internal static class DemoHostFactory
+{
+  public static IHost CreateHost()
+  {
+    var builder = Host.CreateApplicationBuilder();
+    builder.Services.AddDemoApp();
+    return builder.Build();
+  }
+}

--- a/tests/XBase.Demo.App.Tests/IndexManagerViewModelTests.cs
+++ b/tests/XBase.Demo.App.Tests/IndexManagerViewModelTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using XBase.Demo.App.ViewModels;
+using XBase.Demo.Domain.Catalog;
+using XBase.Demo.Domain.Services;
+
+namespace XBase.Demo.App.Tests;
+
+public sealed class IndexManagerViewModelTests
+{
+  [Fact]
+  public async Task CreateAndDropIndexCommand_ManagesPlaceholderFiles()
+  {
+    using var catalog = new TempCatalog();
+    catalog.AddTable("PRODUCTS", addPlaceholderIndex: false);
+
+    using var host = DemoHostFactory.CreateHost();
+    await host.StartAsync();
+
+    try
+    {
+      var indexManager = host.Services.GetRequiredService<IndexManagerViewModel>();
+      var catalogService = host.Services.GetRequiredService<ITableCatalogService>();
+      var catalogModel = await catalogService.LoadCatalogAsync(catalog.Path);
+      var tableModel = Assert.Single(catalogModel.Tables);
+      var tableViewModel = new TableListItemViewModel(tableModel);
+
+      indexManager.SetTargetTable(tableViewModel);
+      indexManager.IndexName = "PRODUCTS.NTX";
+      indexManager.IndexExpression = "UPPER(NAME)";
+
+      var createResult = await indexManager.CreateIndexCommand.Execute().ToTask();
+
+      Assert.True(createResult.Succeeded, createResult.Message);
+      Assert.True(File.Exists(Path.Combine(catalog.Path, "PRODUCTS.NTX")));
+      Assert.Null(indexManager.ErrorMessage);
+      Assert.NotNull(indexManager.StatusMessage);
+
+      var indexViewModel = new IndexListItemViewModel(new IndexModel("PRODUCTS.NTX", "NTX"));
+      var dropResult = await indexManager.DropIndexCommand.Execute(indexViewModel).ToTask();
+
+      Assert.True(dropResult.Succeeded, dropResult.Message);
+      Assert.False(File.Exists(Path.Combine(catalog.Path, "PRODUCTS.NTX")));
+    }
+    finally
+    {
+      await host.StopAsync();
+    }
+  }
+
+  [Fact]
+  public async Task DropIndexCommand_ForMissingIndex_SurfacesError()
+  {
+    using var catalog = new TempCatalog();
+    catalog.AddTable("CUSTOMERS", addPlaceholderIndex: false);
+
+    using var host = DemoHostFactory.CreateHost();
+    await host.StartAsync();
+
+    try
+    {
+      var indexManager = host.Services.GetRequiredService<IndexManagerViewModel>();
+      var catalogService = host.Services.GetRequiredService<ITableCatalogService>();
+      var catalogModel = await catalogService.LoadCatalogAsync(catalog.Path);
+      var tableModel = Assert.Single(catalogModel.Tables);
+      var tableViewModel = new TableListItemViewModel(tableModel);
+
+      indexManager.SetTargetTable(tableViewModel);
+
+      var indexViewModel = new IndexListItemViewModel(new IndexModel("CUSTOMERS.NTX", "NTX"));
+      var dropResult = await indexManager.DropIndexCommand.Execute(indexViewModel).ToTask();
+
+      Assert.False(dropResult.Succeeded);
+      Assert.NotNull(indexManager.ErrorMessage);
+      Assert.Contains("not found", indexManager.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+    finally
+    {
+      await host.StopAsync();
+    }
+  }
+}

--- a/tests/XBase.Demo.App.Tests/SchemaDesignerViewModelTests.cs
+++ b/tests/XBase.Demo.App.Tests/SchemaDesignerViewModelTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using XBase.Demo.App.ViewModels;
+using XBase.Demo.Domain.Schema;
+
+namespace XBase.Demo.App.Tests;
+
+public sealed class SchemaDesignerViewModelTests
+{
+  [Fact]
+  public async Task GenerateCreatePreviewCommand_WithColumns_ProducesScript()
+  {
+    using var host = DemoHostFactory.CreateHost();
+    await host.StartAsync();
+
+    try
+    {
+      var viewModel = host.Services.GetRequiredService<SchemaDesignerViewModel>();
+      viewModel.TableName = "PRODUCTS";
+      viewModel.SetColumns(
+          new SchemaColumnViewModel("ID", "NUMERIC", allowNulls: false, length: 8, scale: 0),
+          new SchemaColumnViewModel("NAME", "CHAR", length: 50));
+
+      var preview = await viewModel.GenerateCreatePreviewCommand.Execute().ToTask();
+
+      Assert.Equal("CreateTable", preview.Operation);
+      Assert.Contains("CREATE TABLE PRODUCTS", viewModel.PreviewUpScript, StringComparison.OrdinalIgnoreCase);
+      Assert.Contains("DROP TABLE PRODUCTS", viewModel.PreviewDownScript, StringComparison.OrdinalIgnoreCase);
+      Assert.Null(viewModel.ErrorMessage);
+    }
+    finally
+    {
+      await host.StopAsync();
+    }
+  }
+
+  [Fact]
+  public async Task GenerateAlterPreviewCommand_WithAddChange_ProducesScript()
+  {
+    using var host = DemoHostFactory.CreateHost();
+    await host.StartAsync();
+
+    try
+    {
+      var viewModel = host.Services.GetRequiredService<SchemaDesignerViewModel>();
+      viewModel.TableName = "CUSTOMERS";
+      viewModel.SetAlterations(
+          new SchemaColumnChangeViewModel(
+              ColumnChangeOperation.Add,
+              "EMAIL",
+              new SchemaColumnViewModel("EMAIL", "CHAR", length: 60)));
+
+      var preview = await viewModel.GenerateAlterPreviewCommand.Execute().ToTask();
+
+      Assert.Equal("AlterTable", preview.Operation);
+      Assert.Contains("ADD COLUMN EMAIL", viewModel.PreviewUpScript, StringComparison.OrdinalIgnoreCase);
+      Assert.Contains("DROP COLUMN EMAIL", viewModel.PreviewDownScript, StringComparison.OrdinalIgnoreCase);
+      Assert.Null(viewModel.ErrorMessage);
+    }
+    finally
+    {
+      await host.StopAsync();
+    }
+  }
+
+  [Fact]
+  public async Task GenerateDropPreviewCommand_WithTable_SetsPreview()
+  {
+    using var host = DemoHostFactory.CreateHost();
+    await host.StartAsync();
+
+    try
+    {
+      var viewModel = host.Services.GetRequiredService<SchemaDesignerViewModel>();
+      viewModel.TableName = "ORDERS";
+
+      var preview = await viewModel.GenerateDropPreviewCommand.Execute().ToTask();
+
+      Assert.Equal("DropTable", preview.Operation);
+      Assert.Contains("DROP TABLE ORDERS", viewModel.PreviewUpScript, StringComparison.OrdinalIgnoreCase);
+      Assert.Contains("CREATE", viewModel.PreviewDownScript, StringComparison.OrdinalIgnoreCase);
+    }
+    finally
+    {
+      await host.StopAsync();
+    }
+  }
+}

--- a/tests/XBase.Demo.App.Tests/ShellViewModelTests.cs
+++ b/tests/XBase.Demo.App.Tests/ShellViewModelTests.cs
@@ -1,12 +1,9 @@
 using System;
-using System.IO;
 using System.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Xunit;
-using XBase.Demo.App.DependencyInjection;
 using XBase.Demo.App.ViewModels;
 
 namespace XBase.Demo.App.Tests;
@@ -19,7 +16,7 @@ public sealed class ShellViewModelTests
     using var catalog = new TempCatalog();
     catalog.AddTable("CUSTOMERS");
 
-    using var host = CreateHost();
+    using var host = DemoHostFactory.CreateHost();
     await host.StartAsync();
 
     try
@@ -48,45 +45,4 @@ public sealed class ShellViewModelTests
     }
   }
 
-  private static IHost CreateHost()
-  {
-    var builder = Host.CreateApplicationBuilder();
-    builder.Services.AddDemoApp();
-    return builder.Build();
-  }
-
-  private sealed class TempCatalog : IDisposable
-  {
-    private readonly DirectoryInfo _directory;
-
-    public TempCatalog()
-    {
-      _directory = Directory.CreateTempSubdirectory("xbase-demo-");
-    }
-
-    public string Path => _directory.FullName;
-
-    public void AddTable(string tableName)
-    {
-      ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
-
-      var tablePath = System.IO.Path.Combine(Path, tableName + ".dbf");
-      File.WriteAllBytes(tablePath, Array.Empty<byte>());
-
-      var indexPath = System.IO.Path.Combine(Path, tableName + ".ntx");
-      File.WriteAllBytes(indexPath, Array.Empty<byte>());
-    }
-
-    public void Dispose()
-    {
-      try
-      {
-        _directory.Delete(true);
-      }
-      catch
-      {
-        // best effort cleanup
-      }
-    }
-  }
 }

--- a/tests/XBase.Demo.App.Tests/TempCatalog.cs
+++ b/tests/XBase.Demo.App.Tests/TempCatalog.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+
+namespace XBase.Demo.App.Tests;
+
+internal sealed class TempCatalog : IDisposable
+{
+  private readonly DirectoryInfo _directory;
+
+  public TempCatalog()
+  {
+    _directory = Directory.CreateTempSubdirectory("xbase-demo-");
+  }
+
+  public string Path => _directory.FullName;
+
+  public void AddTable(string tableName, bool addPlaceholderIndex = true)
+  {
+    ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+
+    var tablePath = System.IO.Path.Combine(Path, tableName + ".dbf");
+    File.WriteAllBytes(tablePath, Array.Empty<byte>());
+
+    if (addPlaceholderIndex)
+    {
+      AddIndex(tableName, tableName + ".ntx");
+    }
+  }
+
+  public void AddIndex(string tableName, string indexName)
+  {
+    ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+    ArgumentException.ThrowIfNullOrWhiteSpace(indexName);
+
+    var indexPath = System.IO.Path.Combine(Path, indexName);
+    File.WriteAllBytes(indexPath, Array.Empty<byte>());
+  }
+
+  public void Dispose()
+  {
+    try
+    {
+      _directory.Delete(true);
+    }
+    catch
+    {
+      // best effort cleanup
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add schema DDL preview domain contracts, infrastructure generator, and reactive viewmodel bindings
- implement filesystem-backed index management with command handlers surfaced through the demo app
- extend demo tests and helpers to cover schema/index workflows and mark milestone M2 tasks as complete

## Testing
- dotnet format
- dotnet build xBase.sln -c Release
- dotnet test xBase.sln --configuration Release

------
https://chatgpt.com/codex/tasks/task_e_68dd91b73a3483229bb10ff84d9b280a