### PR TITLE
feat(demo): add index rebuild diagnostics

### DIFF
--- a/src/demo/XBase.Demo.App/ViewModels/IndexListItemViewModel.cs
+++ b/src/demo/XBase.Demo.App/ViewModels/IndexListItemViewModel.cs
@@ -1,26 +1,112 @@
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using ReactiveUI;
 using XBase.Demo.Domain.Catalog;
+using XBase.Demo.Domain.Services.Models;
 
 namespace XBase.Demo.App.ViewModels;
 
 /// <summary>
 /// Represents an index entry for the selected table.
 /// </summary>
-public sealed class IndexListItemViewModel
+public sealed class IndexListItemViewModel : ReactiveObject
 {
+  private long? _sizeBytes;
+  private DateTimeOffset? _lastModifiedUtc;
+  private IndexPerformanceSnapshot? _lastPerformance;
+
   public IndexListItemViewModel(IndexModel model)
   {
     Model = model ?? throw new ArgumentNullException(nameof(model));
     Name = model.Name;
     Expression = model.Expression;
     Order = model.Order;
+    FullPath = model.FullPath;
+    _sizeBytes = model.SizeBytes;
+    _lastModifiedUtc = model.LastModifiedUtc;
   }
 
-  public IndexModel Model { get; }
+  public IndexModel Model { get; private set; }
 
   public string Name { get; }
 
   public string Expression { get; }
 
   public int Order { get; }
+
+  public string? FullPath { get; }
+
+  public long? SizeBytes
+  {
+    get => _sizeBytes;
+    private set
+    {
+      this.RaiseAndSetIfChanged(ref _sizeBytes, value);
+      this.RaisePropertyChanged(nameof(MetricsSummary));
+    }
+  }
+
+  public DateTimeOffset? LastModifiedUtc
+  {
+    get => _lastModifiedUtc;
+    private set
+    {
+      this.RaiseAndSetIfChanged(ref _lastModifiedUtc, value);
+      this.RaisePropertyChanged(nameof(MetricsSummary));
+    }
+  }
+
+  public IndexPerformanceSnapshot? LastPerformance
+  {
+    get => _lastPerformance;
+    private set
+    {
+      this.RaiseAndSetIfChanged(ref _lastPerformance, value);
+      this.RaisePropertyChanged(nameof(MetricsSummary));
+    }
+  }
+
+  public string MetricsSummary
+  {
+    get
+    {
+      var segments = new List<string>();
+      if (SizeBytes is { } size)
+      {
+        segments.Add(string.Format(CultureInfo.InvariantCulture, "{0:N0} bytes", size));
+      }
+
+      if (LastModifiedUtc is { } modified)
+      {
+        segments.Add($"updated {modified.ToLocalTime():g}");
+      }
+
+      if (LastPerformance is { } performance)
+      {
+        var throughput = performance.BytesPerSecond / 1024d;
+        var duration = performance.Duration.TotalMilliseconds;
+        segments.Add($"rebuilt in {duration:N0} ms @ {throughput:N1} KB/s");
+      }
+
+      return segments.Count == 0
+          ? "No diagnostics captured yet."
+          : string.Join(" • ", segments);
+    }
+  }
+
+  public void UpdateFromModel(IndexModel model)
+  {
+    ArgumentNullException.ThrowIfNull(model);
+    Model = model;
+    SizeBytes = model.SizeBytes;
+    LastModifiedUtc = model.LastModifiedUtc;
+  }
+
+  public void UpdateDiagnostics(long? sizeBytes, DateTimeOffset? lastModifiedUtc, IndexPerformanceSnapshot? performance)
+  {
+    SizeBytes = sizeBytes;
+    LastModifiedUtc = lastModifiedUtc;
+    LastPerformance = performance;
+  }
 }

--- a/src/demo/XBase.Demo.App/ViewModels/IndexManagerViewModel.cs
+++ b/src/demo/XBase.Demo.App/ViewModels/IndexManagerViewModel.cs
@@ -1,47 +1,116 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using ReactiveUI;
+using XBase.Demo.Domain.Diagnostics;
 using XBase.Demo.Domain.Services;
 using XBase.Demo.Domain.Services.Models;
 
 namespace XBase.Demo.App.ViewModels;
 
 /// <summary>
-/// Handles index create/drop operations for the selected table.
+/// Handles index lifecycle management and rebuild diagnostics for the selected table.
 /// </summary>
-public sealed class IndexManagerViewModel : ReactiveObject
+public sealed class IndexManagerViewModel : ReactiveObject, IDisposable
 {
   private readonly IIndexManagementService _indexService;
+  private readonly IDemoTelemetrySink _telemetrySink;
+  private readonly ObservableCollection<IndexListItemViewModel> _indexes = new();
+  private readonly CompositeDisposable _subscriptions = new();
   private TableListItemViewModel? _table;
+  private IndexListItemViewModel? _selectedIndex;
   private string? _indexName;
   private string? _indexExpression;
   private string? _statusMessage;
   private string? _errorMessage;
   private bool _isBusy;
+  private double _rebuildProgress;
+  private bool _isRebuildInProgress;
+  private string? _selectionSummary;
+  private IndexPerformanceSnapshot? _lastPerformance;
+  private string? _lastRebuildStage;
+  private string? _activeOperationIndexName;
 
-  public IndexManagerViewModel(IIndexManagementService indexService)
+  public IndexManagerViewModel(IIndexManagementService indexService, IDemoTelemetrySink telemetrySink)
   {
-    _indexService = indexService;
+    _indexService = indexService ?? throw new ArgumentNullException(nameof(indexService));
+    _telemetrySink = telemetrySink ?? throw new ArgumentNullException(nameof(telemetrySink));
+
+    Indexes = new ReadOnlyObservableCollection<IndexListItemViewModel>(_indexes);
 
     CreateIndexCommand = ReactiveCommand.CreateFromTask(ExecuteCreateIndexAsync);
-    CreateIndexCommand.Subscribe(ApplyResult);
-    CreateIndexCommand.ThrownExceptions.Subscribe(OnFault);
+    CreateIndexCommand
+        .Subscribe(result => ApplyResult("create", result))
+        .DisposeWith(_subscriptions);
+    CreateIndexCommand.ThrownExceptions
+        .Subscribe(exception => OnFault("create", exception))
+        .DisposeWith(_subscriptions);
 
     DropIndexCommand = ReactiveCommand.CreateFromTask<IndexListItemViewModel, IndexOperationResult>(ExecuteDropIndexAsync);
-    DropIndexCommand.Subscribe(ApplyResult);
-    DropIndexCommand.ThrownExceptions.Subscribe(OnFault);
+    DropIndexCommand
+        .Subscribe(result => ApplyResult("drop", result))
+        .DisposeWith(_subscriptions);
+    DropIndexCommand.ThrownExceptions
+        .Subscribe(exception => OnFault("drop", exception))
+        .DisposeWith(_subscriptions);
+
+    var canRebuild = this.WhenAnyValue(vm => vm.SelectedIndex, vm => vm.IsBusy, (index, busy) => index is not null && !busy);
+    RebuildIndexCommand = ReactiveCommand.CreateFromObservable(ExecuteRebuildIndex, canRebuild);
+    RebuildIndexCommand
+        .Subscribe(OnRebuildProgress)
+        .DisposeWith(_subscriptions);
+    RebuildIndexCommand.ThrownExceptions
+        .Subscribe(exception => OnFault("rebuild", exception))
+        .DisposeWith(_subscriptions);
 
     Observable.Merge(
             CreateIndexCommand.IsExecuting,
-            DropIndexCommand.IsExecuting)
-        .Subscribe(isExecuting => IsBusy = isExecuting);
+            DropIndexCommand.IsExecuting,
+            RebuildIndexCommand.IsExecuting)
+        .Subscribe(isExecuting => IsBusy = isExecuting)
+        .DisposeWith(_subscriptions);
+
+    RebuildIndexCommand.IsExecuting
+        .Subscribe(inProgress =>
+        {
+          _lastRebuildStage = null;
+          IsRebuildInProgress = inProgress;
+          if (inProgress)
+          {
+            RebuildProgress = 0d;
+          }
+          else
+          {
+            _activeOperationIndexName = null;
+          }
+        })
+        .DisposeWith(_subscriptions);
+
+    this.WhenAnyValue(vm => vm.SelectedIndex)
+        .Subscribe(index =>
+        {
+          SelectionSummary = index is null
+              ? "Select an index to view diagnostics."
+              : BuildSelectionSummary(index);
+          LastPerformance = index?.LastPerformance;
+        })
+        .DisposeWith(_subscriptions);
   }
+
+  public ReadOnlyObservableCollection<IndexListItemViewModel> Indexes { get; }
 
   public ReactiveCommand<Unit, IndexOperationResult> CreateIndexCommand { get; }
 
   public ReactiveCommand<IndexListItemViewModel, IndexOperationResult> DropIndexCommand { get; }
+
+  public ReactiveCommand<Unit, IndexRebuildProgress> RebuildIndexCommand { get; }
 
   public bool IsBusy
   {
@@ -73,17 +142,79 @@ public sealed class IndexManagerViewModel : ReactiveObject
     private set => this.RaiseAndSetIfChanged(ref _errorMessage, value);
   }
 
+  public IndexListItemViewModel? SelectedIndex
+  {
+    get => _selectedIndex;
+    set => this.RaiseAndSetIfChanged(ref _selectedIndex, value);
+  }
+
+  public double RebuildProgress
+  {
+    get => _rebuildProgress;
+    private set => this.RaiseAndSetIfChanged(ref _rebuildProgress, value);
+  }
+
+  public bool IsRebuildInProgress
+  {
+    get => _isRebuildInProgress;
+    private set => this.RaiseAndSetIfChanged(ref _isRebuildInProgress, value);
+  }
+
+  public string? SelectionSummary
+  {
+    get => _selectionSummary;
+    private set => this.RaiseAndSetIfChanged(ref _selectionSummary, value);
+  }
+
+  public IndexPerformanceSnapshot? LastPerformance
+  {
+    get => _lastPerformance;
+    private set
+    {
+      this.RaiseAndSetIfChanged(ref _lastPerformance, value);
+      this.RaisePropertyChanged(nameof(PerformanceSummary));
+    }
+  }
+
+  public string? PerformanceSummary
+      => LastPerformance is null
+          ? null
+          : string.Format(
+              CultureInfo.InvariantCulture,
+              "Last rebuild completed in {0:N0} ms at {1:N1} KB/s",
+              LastPerformance.Duration.TotalMilliseconds,
+              LastPerformance.BytesPerSecond / 1024d);
+
   public void SetTargetTable(TableListItemViewModel? table)
   {
     _table = table;
     StatusMessage = null;
     ErrorMessage = null;
+    IndexName = null;
+    IndexExpression = null;
+    _indexes.Clear();
+    SelectedIndex = null;
+
     if (table is null)
     {
-      IndexName = null;
-      IndexExpression = null;
+      SelectionSummary = "Select a table to view diagnostics.";
+      return;
+    }
+
+    foreach (var index in table.Indexes)
+    {
+      _indexes.Add(index);
+    }
+
+    SelectedIndex = _indexes.FirstOrDefault();
+    if (_indexes.Count == 0)
+    {
+      SelectionSummary = "No indexes discovered for this table.";
     }
   }
+
+  public void Dispose()
+    => _subscriptions.Dispose();
 
   private async Task<IndexOperationResult> ExecuteCreateIndexAsync()
   {
@@ -97,6 +228,7 @@ public sealed class IndexManagerViewModel : ReactiveObject
       throw new InvalidOperationException("Index name and expression are required.");
     }
 
+    _activeOperationIndexName = IndexName;
     var request = IndexCreateRequest.Create(_table.Model.Path, IndexName!, IndexExpression!);
     return await _indexService.CreateIndexAsync(request);
   }
@@ -109,27 +241,139 @@ public sealed class IndexManagerViewModel : ReactiveObject
       throw new InvalidOperationException("Select a table before dropping an index.");
     }
 
+    _activeOperationIndexName = index.Name;
     var request = IndexDropRequest.Create(_table.Model.Path, index.Name);
     return await _indexService.DropIndexAsync(request);
   }
 
-  private void ApplyResult(IndexOperationResult result)
+  private IObservable<IndexRebuildProgress> ExecuteRebuildIndex()
   {
+    if (_table is null)
+    {
+      return Observable.Throw<IndexRebuildProgress>(new InvalidOperationException("Select a table before rebuilding an index."));
+    }
+
+    if (SelectedIndex is null)
+    {
+      return Observable.Throw<IndexRebuildProgress>(new InvalidOperationException("Select an index to rebuild."));
+    }
+
+    _activeOperationIndexName = SelectedIndex.Name;
+    var request = IndexRebuildRequest.Create(_table.Model.Path, SelectedIndex.Name);
+    PublishTelemetry("IndexRebuildRequested", new Dictionary<string, object?>
+    {
+      ["table"] = _table.Name,
+      ["index"] = SelectedIndex.Name
+    });
+
+    return _indexService.RebuildIndex(request);
+  }
+
+  private void ApplyResult(string operation, IndexOperationResult result)
+  {
+    var indexName = _activeOperationIndexName ?? SelectedIndex?.Name ?? IndexName ?? string.Empty;
     if (result.Succeeded)
     {
       StatusMessage = result.Message;
       ErrorMessage = null;
+      PublishTelemetry($"Index{ToOperationName(operation)}Succeeded", new Dictionary<string, object?>
+      {
+        ["table"] = _table?.Name,
+        ["index"] = indexName,
+        ["message"] = result.Message
+      });
     }
     else
     {
       StatusMessage = null;
       ErrorMessage = result.Message;
+      PublishTelemetry($"Index{ToOperationName(operation)}Failed", new Dictionary<string, object?>
+      {
+        ["table"] = _table?.Name,
+        ["index"] = indexName,
+        ["message"] = result.Message
+      });
+    }
+
+    _activeOperationIndexName = null;
+  }
+
+  private void OnRebuildProgress(IndexRebuildProgress progress)
+  {
+    ErrorMessage = null;
+    RebuildProgress = progress.PercentComplete;
+    StatusMessage = progress.Message;
+
+    if (!string.Equals(_lastRebuildStage, progress.Stage, StringComparison.Ordinal))
+    {
+      PublishTelemetry($"IndexRebuild{progress.Stage}", new Dictionary<string, object?>
+      {
+        ["table"] = _table?.Name,
+        ["index"] = SelectedIndex?.Name,
+        ["stage"] = progress.Stage,
+        ["progress"] = progress.PercentComplete,
+        ["bytesProcessed"] = progress.BytesProcessed,
+        ["totalBytes"] = progress.TotalBytes
+      });
+      _lastRebuildStage = progress.Stage;
+    }
+
+    if (progress.Performance is not null)
+    {
+      LastPerformance = progress.Performance;
+    }
+
+    if (progress.IsCompleted && SelectedIndex is not null && _table is not null)
+    {
+      var tableDirectory = Path.GetDirectoryName(_table.Model.Path) ?? string.Empty;
+      var indexPath = SelectedIndex.FullPath ?? Path.Combine(tableDirectory, SelectedIndex.Name);
+      var fileInfo = new FileInfo(indexPath);
+      SelectedIndex.UpdateDiagnostics(
+          fileInfo.Exists ? fileInfo.Length : progress.BytesProcessed,
+          fileInfo.Exists ? fileInfo.LastWriteTimeUtc : DateTimeOffset.UtcNow,
+          progress.Performance);
+      SelectionSummary = BuildSelectionSummary(SelectedIndex);
+
+      PublishTelemetry("IndexRebuildCompleted", new Dictionary<string, object?>
+      {
+        ["table"] = _table.Name,
+        ["index"] = SelectedIndex.Name,
+        ["durationMs"] = progress.Performance?.Duration.TotalMilliseconds,
+        ["throughputBytesPerSecond"] = progress.Performance?.BytesPerSecond,
+        ["bytesProcessed"] = progress.BytesProcessed
+      });
+
+      _activeOperationIndexName = null;
     }
   }
 
-  private void OnFault(Exception exception)
+  private void OnFault(string operation, Exception exception)
   {
     StatusMessage = null;
     ErrorMessage = exception.Message;
+
+    PublishTelemetry($"Index{ToOperationName(operation)}Fault", new Dictionary<string, object?>
+    {
+      ["table"] = _table?.Name,
+      ["index"] = _activeOperationIndexName ?? SelectedIndex?.Name ?? IndexName,
+      ["message"] = exception.Message
+    });
+
+    _activeOperationIndexName = null;
   }
+
+  private static string BuildSelectionSummary(IndexListItemViewModel index)
+      => $"{index.Name} • {index.MetricsSummary}";
+
+  private static string ToOperationName(string operation)
+      => operation switch
+      {
+        "create" => "Create",
+        "drop" => "Drop",
+        "rebuild" => "Rebuild",
+        _ => "Operation"
+      };
+
+  private void PublishTelemetry(string eventName, IReadOnlyDictionary<string, object?> payload)
+    => _telemetrySink.Publish(new DemoTelemetryEvent(eventName, DateTimeOffset.UtcNow, payload));
 }

--- a/src/demo/XBase.Demo.App/Views/MainWindow.axaml
+++ b/src/demo/XBase.Demo.App/Views/MainWindow.axaml
@@ -31,9 +31,25 @@
 
       <Border Grid.Column="1" BorderBrush="#FF4D596A" BorderThickness="1" CornerRadius="6" Padding="6" Margin="0,0,12,0">
         <Grid RowDefinitions="Auto,*">
-          <StackPanel Grid.Row="0" Orientation="Vertical" Spacing="6" Margin="0,0,0,8">
+          <StackPanel Grid.Row="0" Orientation="Vertical" Spacing="8" Margin="0,0,0,8" DataContext="{Binding IndexManager}">
             <TextBlock Text="Indexes" FontWeight="SemiBold" />
-            <ListBox ItemsSource="{Binding SelectedTable.Indexes}" Height="200" />
+            <ListBox ItemsSource="{Binding Indexes}" SelectedItem="{Binding SelectedIndex}" Height="200">
+              <ListBox.ItemTemplate>
+                <DataTemplate>
+                  <StackPanel Spacing="2">
+                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
+                    <TextBlock Text="{Binding Expression}" FontSize="12" Foreground="#FF56687A" />
+                    <TextBlock Text="{Binding MetricsSummary}" FontSize="11" Foreground="#FF6C7A89" TextWrapping="Wrap" />
+                  </StackPanel>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+            <TextBlock Text="{Binding SelectionSummary}" TextWrapping="Wrap" />
+            <Button Content="Rebuild Index" Command="{Binding RebuildIndexCommand}" />
+            <ProgressBar Minimum="0" Maximum="1" Value="{Binding RebuildProgress}" Height="10" IsVisible="{Binding IsRebuildInProgress}" />
+            <TextBlock Text="{Binding StatusMessage}" FontWeight="Medium" Foreground="#FF2E4457" TextWrapping="Wrap" />
+            <TextBlock Text="{Binding PerformanceSummary}" Foreground="#FF2E4457" FontStyle="Italic" TextWrapping="Wrap" />
+            <TextBlock Text="{Binding ErrorMessage}" Foreground="#FFB00020" TextWrapping="Wrap" />
           </StackPanel>
           <Grid Grid.Row="1" RowDefinitions="Auto,*">
             <TextBlock Grid.Row="0" Text="Telemetry" FontWeight="SemiBold" />

--- a/src/demo/XBase.Demo.Diagnostics/InMemoryTelemetrySink.cs
+++ b/src/demo/XBase.Demo.Diagnostics/InMemoryTelemetrySink.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using XBase.Demo.Domain.Diagnostics;
 
 namespace XBase.Demo.Diagnostics;
@@ -13,6 +15,7 @@ public sealed class InMemoryTelemetrySink : IDemoTelemetrySink
 {
   private readonly ConcurrentQueue<DemoTelemetryEvent> _events = new();
   private readonly ILogger<InMemoryTelemetrySink> _logger;
+  private readonly Subject<DemoTelemetryEvent> _eventStream = new();
 
   public InMemoryTelemetrySink(ILogger<InMemoryTelemetrySink> logger)
   {
@@ -29,6 +32,7 @@ public sealed class InMemoryTelemetrySink : IDemoTelemetrySink
     }
 
     _logger.LogInformation("Telemetry event {Name} captured", telemetryEvent.Name);
+    _eventStream.OnNext(telemetryEvent);
   }
 
   /// <summary>
@@ -36,4 +40,6 @@ public sealed class InMemoryTelemetrySink : IDemoTelemetrySink
   /// </summary>
   public IReadOnlyCollection<DemoTelemetryEvent> GetSnapshot()
       => _events.ToArray();
+
+  public IObservable<DemoTelemetryEvent> Events => _eventStream.AsObservable();
 }

--- a/src/demo/XBase.Demo.Diagnostics/XBase.Demo.Diagnostics.csproj
+++ b/src/demo/XBase.Demo.Diagnostics/XBase.Demo.Diagnostics.csproj
@@ -7,5 +7,6 @@
     <ProjectReference Include="../XBase.Demo.Domain/XBase.Demo.Domain.csproj" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/src/demo/XBase.Demo.Domain/Catalog/CatalogModel.cs
+++ b/src/demo/XBase.Demo.Domain/Catalog/CatalogModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace XBase.Demo.Domain.Catalog;
@@ -23,4 +24,20 @@ public sealed record TableModel(string Name, string Path, IReadOnlyList<IndexMod
 /// <param name="Name">Index identifier.</param>
 /// <param name="Expression">The expression used to compute the index key.</param>
 /// <param name="Order">Optional ordering hint for display.</param>
-public sealed record IndexModel(string Name, string Expression, int Order = 0);
+public sealed record IndexModel(string Name, string Expression, int Order = 0)
+{
+  /// <summary>
+  /// Gets the absolute path to the index artifact when known.
+  /// </summary>
+  public string? FullPath { get; init; }
+
+  /// <summary>
+  /// Gets the recorded size of the index artifact in bytes, if available.
+  /// </summary>
+  public long? SizeBytes { get; init; }
+
+  /// <summary>
+  /// Gets the last modified timestamp of the index artifact expressed in UTC.
+  /// </summary>
+  public DateTimeOffset? LastModifiedUtc { get; init; }
+}

--- a/src/demo/XBase.Demo.Domain/Diagnostics/DemoTelemetryEvent.cs
+++ b/src/demo/XBase.Demo.Domain/Diagnostics/DemoTelemetryEvent.cs
@@ -17,4 +17,8 @@ public sealed record DemoTelemetryEvent(string Name, DateTimeOffset Timestamp, I
 public interface IDemoTelemetrySink
 {
   void Publish(DemoTelemetryEvent telemetryEvent);
+
+  IObservable<DemoTelemetryEvent> Events { get; }
+
+  IReadOnlyCollection<DemoTelemetryEvent> GetSnapshot();
 }

--- a/src/demo/XBase.Demo.Domain/Services/IIndexManagementService.cs
+++ b/src/demo/XBase.Demo.Domain/Services/IIndexManagementService.cs
@@ -13,4 +13,6 @@ public interface IIndexManagementService
   Task<IndexOperationResult> CreateIndexAsync(IndexCreateRequest request, CancellationToken cancellationToken = default);
 
   Task<IndexOperationResult> DropIndexAsync(IndexDropRequest request, CancellationToken cancellationToken = default);
+
+  IObservable<IndexRebuildProgress> RebuildIndex(IndexRebuildRequest request);
 }

--- a/src/demo/XBase.Demo.Domain/Services/Models/IndexRequests.cs
+++ b/src/demo/XBase.Demo.Domain/Services/Models/IndexRequests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 
 namespace XBase.Demo.Domain.Services.Models;
 
@@ -32,6 +33,76 @@ public sealed record IndexDropRequest(string TablePath, string IndexName)
     ArgumentException.ThrowIfNullOrWhiteSpace(indexName);
     return new IndexDropRequest(tablePath, indexName);
   }
+}
+
+/// <summary>
+/// Describes the inputs required to rebuild an index alongside the existing artifact.
+/// </summary>
+/// <param name="TablePath">Absolute path to the table (DBF) file.</param>
+/// <param name="IndexName">Logical index name including extension.</param>
+/// <param name="TemporaryIndexName">Optional override for the temporary index artifact name.</param>
+public sealed record IndexRebuildRequest(string TablePath, string IndexName, string? TemporaryIndexName = null)
+{
+  public static IndexRebuildRequest Create(string tablePath, string indexName, string? temporaryIndexName = null)
+  {
+    ArgumentException.ThrowIfNullOrWhiteSpace(tablePath);
+    ArgumentException.ThrowIfNullOrWhiteSpace(indexName);
+    if (!string.IsNullOrWhiteSpace(temporaryIndexName) && Path.GetFileName(temporaryIndexName) != temporaryIndexName)
+    {
+      throw new ArgumentException("Temporary index name must not contain directory segments.", nameof(temporaryIndexName));
+    }
+
+    return new IndexRebuildRequest(tablePath, indexName, temporaryIndexName);
+  }
+}
+
+/// <summary>
+/// Captures performance characteristics for a completed index operation.
+/// </summary>
+/// <param name="Duration">Total execution time.</param>
+/// <param name="BytesProcessed">Number of bytes processed during the operation.</param>
+public sealed record IndexPerformanceSnapshot(TimeSpan Duration, long BytesProcessed)
+{
+  public double BytesPerSecond => Duration > TimeSpan.Zero
+      ? BytesProcessed / Duration.TotalSeconds
+      : BytesProcessed;
+}
+
+/// <summary>
+/// Represents progress emitted during an index rebuild operation.
+/// </summary>
+/// <param name="Stage">Logical stage of execution.</param>
+/// <param name="PercentComplete">Percentage complete represented as 0.0 - 1.0.</param>
+/// <param name="Message">Human-readable status message.</param>
+/// <param name="BytesProcessed">Number of bytes processed so far.</param>
+/// <param name="TotalBytes">Total bytes expected for the operation, if known.</param>
+/// <param name="Performance">Performance metrics available for completed stages.</param>
+/// <param name="IsCompleted">Indicates whether the rebuild has completed successfully.</param>
+public sealed record IndexRebuildProgress(
+    string Stage,
+    double PercentComplete,
+    string Message,
+    long BytesProcessed = 0,
+    long? TotalBytes = null,
+    IndexPerformanceSnapshot? Performance = null,
+    bool IsCompleted = false)
+{
+  public static IndexRebuildProgress Starting(string indexPath, long? totalBytes)
+      => new("Preparing", 0d, $"Preparing rebuild for {Path.GetFileName(indexPath)}", 0, totalBytes);
+
+  public static IndexRebuildProgress Copying(long bytesProcessed, long? totalBytes)
+  {
+    var percent = totalBytes is > 0
+        ? Math.Clamp(bytesProcessed / (double)totalBytes.Value, 0d, 1d)
+        : 0.5d;
+    return new IndexRebuildProgress("Copying", percent, "Cloning index side-by-side", bytesProcessed, totalBytes);
+  }
+
+  public static IndexRebuildProgress Swapping(long? totalBytes)
+      => new("Swapping", 0.95d, "Swapping rebuilt index into place", totalBytes ?? 0, totalBytes);
+
+  public static IndexRebuildProgress Completed(string indexPath, IndexPerformanceSnapshot performance)
+      => new("Completed", 1d, $"Index '{Path.GetFileName(indexPath)}' rebuilt successfully.", performance.BytesProcessed, performance.BytesProcessed, performance, true);
 }
 
 /// <summary>

--- a/src/demo/XBase.Demo.Infrastructure/Catalog/FileSystemTableCatalogService.cs
+++ b/src/demo/XBase.Demo.Infrastructure/Catalog/FileSystemTableCatalogService.cs
@@ -49,7 +49,13 @@ public sealed class FileSystemTableCatalogService : ITableCatalogService
           continue;
         }
 
-        indexes.Add(new IndexModel(Path.GetFileName(indexFile), extension.ToUpperInvariant()));
+        var fileInfo = new FileInfo(indexFile);
+        indexes.Add(new IndexModel(Path.GetFileName(indexFile), extension.ToUpperInvariant())
+        {
+          FullPath = fileInfo.FullName,
+          SizeBytes = fileInfo.Exists ? fileInfo.Length : null,
+          LastModifiedUtc = fileInfo.Exists ? fileInfo.LastWriteTimeUtc : null
+        });
       }
 
       tables.Add(new TableModel(tableName, tableFile, indexes));

--- a/src/demo/XBase.Demo.Infrastructure/Indexes/FileSystemIndexManagementService.cs
+++ b/src/demo/XBase.Demo.Infrastructure/Indexes/FileSystemIndexManagementService.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Diagnostics;
 using System.IO;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -74,6 +77,126 @@ public sealed class FileSystemIndexManagementService : IIndexManagementService
       _logger.LogError(ex, "Failed to drop index {Index} for table {Table}", request.IndexName, request.TablePath);
       return Task.FromResult(IndexOperationResult.Failure($"Failed to drop index '{request.IndexName}'. {ex.Message}", ex));
     }
+  }
+
+  public IObservable<IndexRebuildProgress> RebuildIndex(IndexRebuildRequest request)
+  {
+    ArgumentNullException.ThrowIfNull(request);
+
+    return Observable.Create<IndexRebuildProgress>(observer =>
+    {
+      var cancellation = new CancellationTokenSource();
+
+      _ = Task.Run(async () =>
+      {
+        string? temporaryIndexPath = null;
+        string? backupPath = null;
+        try
+        {
+          var tableDirectory = ResolveTableDirectory(request.TablePath);
+          var originalIndexPath = Path.Combine(tableDirectory, request.IndexName);
+          if (!File.Exists(originalIndexPath))
+          {
+            throw new FileNotFoundException($"Index '{request.IndexName}' was not found.", originalIndexPath);
+          }
+
+          var temporaryName = string.IsNullOrWhiteSpace(request.TemporaryIndexName)
+              ? $"{Path.GetFileNameWithoutExtension(request.IndexName)}.rebuilt{Path.GetExtension(request.IndexName)}"
+              : request.TemporaryIndexName;
+          temporaryIndexPath = Path.Combine(tableDirectory, temporaryName);
+          backupPath = Path.Combine(tableDirectory, $"{request.IndexName}.bak");
+
+          if (File.Exists(temporaryIndexPath))
+          {
+            File.Delete(temporaryIndexPath);
+          }
+
+          if (File.Exists(backupPath))
+          {
+            File.Delete(backupPath);
+          }
+
+          var sourceInfo = new FileInfo(originalIndexPath);
+          var totalBytes = sourceInfo.Exists ? sourceInfo.Length : 0;
+
+          observer.OnNext(IndexRebuildProgress.Starting(originalIndexPath, totalBytes));
+
+          long bytesCopied = 0;
+          var stopwatch = Stopwatch.StartNew();
+          await using (var readStream = new FileStream(originalIndexPath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true))
+          await using (var writeStream = new FileStream(temporaryIndexPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 4096, useAsync: true))
+          {
+            var buffer = new byte[81920];
+            while (true)
+            {
+              cancellation.Token.ThrowIfCancellationRequested();
+              var bytesRead = await readStream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellation.Token);
+              if (bytesRead == 0)
+              {
+                break;
+              }
+
+              await writeStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellation.Token);
+              bytesCopied += bytesRead;
+              observer.OnNext(IndexRebuildProgress.Copying(bytesCopied, totalBytes));
+            }
+
+            await writeStream.FlushAsync(cancellation.Token);
+          }
+
+          observer.OnNext(IndexRebuildProgress.Swapping(totalBytes));
+
+          File.Move(originalIndexPath, backupPath, overwrite: true);
+          File.Move(temporaryIndexPath, originalIndexPath, overwrite: true);
+          File.Delete(backupPath);
+
+          var finalInfo = new FileInfo(originalIndexPath);
+          stopwatch.Stop();
+          var performance = new IndexPerformanceSnapshot(stopwatch.Elapsed, finalInfo.Exists ? finalInfo.Length : bytesCopied);
+          observer.OnNext(IndexRebuildProgress.Completed(originalIndexPath, performance));
+          observer.OnCompleted();
+
+          _logger.LogInformation("Rebuilt index placeholder {Index} for table {Table}", originalIndexPath, request.TablePath);
+        }
+        catch (OperationCanceledException)
+        {
+          observer.OnCompleted();
+        }
+        catch (Exception ex)
+        {
+          _logger.LogError(ex, "Failed to rebuild index {Index} for table {Table}", request.IndexName, request.TablePath);
+          observer.OnError(ex);
+        }
+        finally
+        {
+          if (!string.IsNullOrWhiteSpace(temporaryIndexPath) && File.Exists(temporaryIndexPath))
+          {
+            try
+            {
+              File.Delete(temporaryIndexPath);
+            }
+            catch (Exception cleanupEx)
+            {
+              _logger.LogWarning(cleanupEx, "Failed to cleanup temporary index artifact {Index}", temporaryIndexPath);
+            }
+          }
+
+          if (!string.IsNullOrWhiteSpace(backupPath) && File.Exists(backupPath))
+          {
+            try
+            {
+              File.Delete(backupPath);
+            }
+            catch (Exception cleanupEx)
+            {
+              _logger.LogWarning(cleanupEx, "Failed to cleanup backup index artifact {Index}", backupPath);
+            }
+          }
+        }
+      }, cancellation.Token);
+
+      return Disposable.Create(() => cancellation.Cancel());
+    });
   }
 
   private static string ResolveTableDirectory(string tablePath)

--- a/src/demo/XBase.Demo.Infrastructure/XBase.Demo.Infrastructure.csproj
+++ b/src/demo/XBase.Demo.Infrastructure/XBase.Demo.Infrastructure.csproj
@@ -10,5 +10,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add index rebuild orchestration APIs with progress metrics and filesystem implementation
- surface rebuild controls, metrics, and telemetry bindings in the Avalonia shell
- expose reactive telemetry streams and richer index metadata for diagnostics

## Testing
- dotnet format xBase.sln
- dotnet build xBase.sln -c Release
- dotnet test xBase.sln -c Release

------
https://chatgpt.com/codex/tasks/task_e_68dd94b2ebc48322b20698d4d202a014