### PR TITLE
fix: allow demo catalog to detect uppercase DBF files

### DIFF
--- a/src/demo/XBase.Demo.Infrastructure/Catalog/FileSystemTableCatalogService.cs
+++ b/src/demo/XBase.Demo.Infrastructure/Catalog/FileSystemTableCatalogService.cs
@@ -33,7 +33,12 @@ public sealed class FileSystemTableCatalogService : ITableCatalogService
     var absoluteRoot = Path.GetFullPath(rootPath);
     var tables = new List<TableModel>();
 
-    foreach (var tableFile in Directory.EnumerateFiles(absoluteRoot, "*.dbf", SearchOption.TopDirectoryOnly))
+    var tableFiles = Directory
+      .EnumerateFiles(absoluteRoot, "*", SearchOption.TopDirectoryOnly)
+      .Where(file => string.Equals(Path.GetExtension(file), ".dbf", StringComparison.OrdinalIgnoreCase))
+      .Distinct(StringComparer.OrdinalIgnoreCase);
+
+    foreach (var tableFile in tableFiles)
     {
       cancellationToken.ThrowIfCancellationRequested();
 

--- a/tests/XBase.Demo.App.Tests/FileSystemTableCatalogServiceTests.cs
+++ b/tests/XBase.Demo.App.Tests/FileSystemTableCatalogServiceTests.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using XBase.Demo.Infrastructure.Catalog;
+
+namespace XBase.Demo.App.Tests;
+
+public sealed class FileSystemTableCatalogServiceTests
+{
+  [Fact]
+  public async Task LoadCatalogAsync_FindsUppercaseDbfExtensions()
+  {
+    using var catalog = new TempCatalog();
+    var tablePath = Path.Combine(catalog.Path, "CUSTOMERS.DBF");
+    await File.WriteAllBytesAsync(tablePath, Array.Empty<byte>());
+
+    var service = new FileSystemTableCatalogService(NullLogger<FileSystemTableCatalogService>.Instance);
+    var model = await service.LoadCatalogAsync(catalog.Path);
+
+    Assert.Single(model.Tables);
+    Assert.Equal("CUSTOMERS", model.Tables[0].Name);
+    Assert.Equal(tablePath, model.Tables[0].Path);
+  }
+}


### PR DESCRIPTION
## Summary
- treat demo catalog enumeration as case-insensitive for DBF extensions
- add regression coverage to ensure uppercase DBF files are discovered

## Testing
- dotnet test tests/XBase.Demo.App.Tests/XBase.Demo.App.Tests.csproj --configuration Release

------
https://chatgpt.com/codex/tasks/task_e_68dd9db3bc348322a5e33d5aafa87bb6