### PR TITLE
feat(demo): implement real index artifacts for demo catalog

### DIFF
--- a/src/demo/XBase.Demo.Domain/Catalog/CatalogModel.cs
+++ b/src/demo/XBase.Demo.Domain/Catalog/CatalogModel.cs
@@ -40,4 +40,19 @@ public sealed record IndexModel(string Name, string Expression, int Order = 0)
   /// Gets the last modified timestamp of the index artifact expressed in UTC.
   /// </summary>
   public DateTimeOffset? LastModifiedUtc { get; init; }
+
+  /// <summary>
+  /// Gets the signature derived from the indexed keys for change detection.
+  /// </summary>
+  public string? Signature { get; init; }
+
+  /// <summary>
+  /// Gets the number of non-deleted records captured in the index artifact, when available.
+  /// </summary>
+  public int? ActiveRecordCount { get; init; }
+
+  /// <summary>
+  /// Gets the total number of records (including deleted entries) captured when building the index.
+  /// </summary>
+  public int? TotalRecordCount { get; init; }
 }

--- a/src/demo/XBase.Demo.Infrastructure/Catalog/FileSystemTableCatalogService.cs
+++ b/src/demo/XBase.Demo.Infrastructure/Catalog/FileSystemTableCatalogService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using XBase.Demo.Domain.Catalog;
 using XBase.Demo.Domain.Services;
@@ -55,11 +56,15 @@ public sealed class FileSystemTableCatalogService : ITableCatalogService
         }
 
         var fileInfo = new FileInfo(indexFile);
-        indexes.Add(new IndexModel(Path.GetFileName(indexFile), extension.ToUpperInvariant())
+        var metadata = TryReadIndexMetadata(fileInfo);
+        indexes.Add(new IndexModel(Path.GetFileName(indexFile), metadata?.Expression ?? extension.ToUpperInvariant())
         {
           FullPath = fileInfo.FullName,
           SizeBytes = fileInfo.Exists ? fileInfo.Length : null,
-          LastModifiedUtc = fileInfo.Exists ? fileInfo.LastWriteTimeUtc : null
+          LastModifiedUtc = fileInfo.Exists ? fileInfo.LastWriteTimeUtc : null,
+          Signature = metadata?.Signature,
+          ActiveRecordCount = metadata?.ActiveRecords,
+          TotalRecordCount = metadata?.TotalRecords
         });
       }
 
@@ -69,4 +74,68 @@ public sealed class FileSystemTableCatalogService : ITableCatalogService
     _logger.LogInformation("Discovered {TableCount} tables under {RootPath}", tables.Count, absoluteRoot);
     return Task.FromResult(new CatalogModel(absoluteRoot, tables));
   }
+
+  private static IndexMetadata? TryReadIndexMetadata(FileInfo fileInfo)
+  {
+    try
+    {
+      if (!fileInfo.Exists)
+      {
+        return null;
+      }
+
+      using var stream = new FileStream(fileInfo.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+      using var document = JsonDocument.Parse(stream);
+      var root = document.RootElement;
+
+      if (!root.TryGetProperty("formatVersion", out _))
+      {
+        return null;
+      }
+
+      if (!root.TryGetProperty("expression", out var expressionElement))
+      {
+        return null;
+      }
+
+      var expression = expressionElement.GetString();
+      if (string.IsNullOrWhiteSpace(expression))
+      {
+        return null;
+      }
+
+      string? signature = null;
+      if (root.TryGetProperty("signature", out var signatureElement))
+      {
+        signature = signatureElement.GetString();
+      }
+
+      int? activeRecords = null;
+      int? totalRecords = null;
+      if (root.TryGetProperty("statistics", out var statsElement))
+      {
+        if (statsElement.TryGetProperty("activeRecords", out var activeElement))
+        {
+          activeRecords = activeElement.GetInt32();
+        }
+
+        if (statsElement.TryGetProperty("totalRecords", out var totalElement))
+        {
+          totalRecords = totalElement.GetInt32();
+        }
+      }
+
+      return new IndexMetadata(expression, signature, activeRecords, totalRecords);
+    }
+    catch (JsonException)
+    {
+      return null;
+    }
+    catch (IOException)
+    {
+      return null;
+    }
+  }
+
+  private sealed record IndexMetadata(string Expression, string? Signature, int? ActiveRecords, int? TotalRecords);
 }

--- a/src/demo/XBase.Demo.Infrastructure/Indexes/IndexKeyExpressionCompiler.cs
+++ b/src/demo/XBase.Demo.Infrastructure/Indexes/IndexKeyExpressionCompiler.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using XBase.Expressions.Evaluation;
+
+namespace XBase.Demo.Infrastructure.Indexes;
+
+internal static class IndexKeyExpressionCompiler
+{
+  public static Func<IReadOnlyDictionary<string, object?>, string?> Compile(
+    string expression,
+    IEnumerable<string> columns,
+    ExpressionEvaluator evaluator)
+  {
+    ArgumentException.ThrowIfNullOrWhiteSpace(expression);
+    ArgumentNullException.ThrowIfNull(columns);
+    ArgumentNullException.ThrowIfNull(evaluator);
+
+    var columnSet = new HashSet<string>(columns, StringComparer.OrdinalIgnoreCase);
+    var root = ParseExpression(expression.AsSpan(), evaluator, columnSet);
+
+    return row =>
+    {
+      ArgumentNullException.ThrowIfNull(row);
+      var value = root.Evaluate(row);
+      return FormatValue(value);
+    };
+  }
+
+  private static Node ParseExpression(
+    ReadOnlySpan<char> expression,
+    ExpressionEvaluator evaluator,
+    ISet<string> columns)
+  {
+    expression = expression.Trim();
+    if (expression.IsEmpty)
+    {
+      throw new FormatException("Index expression cannot be empty.");
+    }
+
+    while (IsWrappedByParentheses(expression))
+    {
+      expression = expression[1..^1].Trim();
+    }
+
+    var operatorIndex = FindTopLevelOperator(expression, '+');
+    if (operatorIndex >= 0)
+    {
+      var left = ParseExpression(expression[..operatorIndex], evaluator, columns);
+      var right = ParseExpression(expression[(operatorIndex + 1)..], evaluator, columns);
+      return new ConcatNode(left, right);
+    }
+
+    if (expression.Length >= 2 &&
+        (expression[0] == '\'' && expression[^1] == '\'' || expression[0] == '"' && expression[^1] == '"'))
+    {
+      return new LiteralNode(UnescapeLiteral(expression));
+    }
+
+    var openParenIndex = FindTopLevelOpenParenthesis(expression);
+    if (openParenIndex > 0 && expression[^1] == ')')
+    {
+      var functionName = expression[..openParenIndex].Trim();
+      if (functionName.IsEmpty)
+      {
+        throw new FormatException("Function name cannot be empty in index expression.");
+      }
+
+      var argument = expression[(openParenIndex + 1)..^1];
+      var argumentNode = ParseExpression(argument, evaluator, columns);
+      return new FunctionNode(functionName.ToString(), argumentNode, evaluator);
+    }
+
+    var columnName = expression.ToString();
+    if (!columns.Contains(columnName))
+    {
+      throw new InvalidOperationException($"Column '{columnName}' referenced in index expression was not found.");
+    }
+
+    return new FieldNode(columnName);
+  }
+
+  private static bool IsWrappedByParentheses(ReadOnlySpan<char> expression)
+  {
+    if (expression.Length < 2 || expression[0] != '(' || expression[^1] != ')')
+    {
+      return false;
+    }
+
+    var depth = 0;
+    for (var index = 0; index < expression.Length; index++)
+    {
+      var current = expression[index];
+      if (current == '(')
+      {
+        depth++;
+      }
+      else if (current == ')')
+      {
+        depth--;
+        if (depth == 0 && index < expression.Length - 1)
+        {
+          return false;
+        }
+      }
+    }
+
+    return depth == 0;
+  }
+
+  private static int FindTopLevelOperator(ReadOnlySpan<char> expression, char operatorToken)
+  {
+    var depth = 0;
+    for (var index = 0; index < expression.Length; index++)
+    {
+      var current = expression[index];
+      if (current == '(')
+      {
+        depth++;
+      }
+      else if (current == ')')
+      {
+        depth--;
+      }
+      else if (depth == 0 && current == operatorToken)
+      {
+        return index;
+      }
+    }
+
+    return -1;
+  }
+
+  private static int FindTopLevelOpenParenthesis(ReadOnlySpan<char> expression)
+  {
+    var depth = 0;
+    for (var index = 0; index < expression.Length; index++)
+    {
+      var current = expression[index];
+      if (current == '(')
+      {
+        if (depth == 0)
+        {
+          return index;
+        }
+
+        depth++;
+      }
+      else if (current == ')')
+      {
+        depth--;
+      }
+    }
+
+    return -1;
+  }
+
+  private static string UnescapeLiteral(ReadOnlySpan<char> literal)
+  {
+    if (literal.Length < 2)
+    {
+      return string.Empty;
+    }
+
+    var body = literal[1..^1];
+    var builder = new StringBuilder(body.Length);
+    for (var index = 0; index < body.Length; index++)
+    {
+      var current = body[index];
+      if ((current == '\'' || current == '"') && index + 1 < body.Length && body[index + 1] == current)
+      {
+        builder.Append(current);
+        index++;
+      }
+      else
+      {
+        builder.Append(current);
+      }
+    }
+
+    return builder.ToString();
+  }
+
+  private static string? FormatValue(object? value)
+  {
+    if (value is null)
+    {
+      return null;
+    }
+
+    return value switch
+    {
+      string text => text,
+      bool flag => flag ? "T" : "F",
+      DateTime date => date.ToString("yyyyMMdd", CultureInfo.InvariantCulture),
+      IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+      _ => Convert.ToString(value, CultureInfo.InvariantCulture)
+    };
+  }
+
+  private abstract class Node
+  {
+    public abstract object? Evaluate(IReadOnlyDictionary<string, object?> row);
+  }
+
+  private sealed class FieldNode : Node
+  {
+    private readonly string _columnName;
+
+    public FieldNode(string columnName)
+    {
+      _columnName = columnName;
+    }
+
+    public override object? Evaluate(IReadOnlyDictionary<string, object?> row)
+    {
+      row.TryGetValue(_columnName, out var value);
+      return value;
+    }
+  }
+
+  private sealed class LiteralNode : Node
+  {
+    private readonly string _value;
+
+    public LiteralNode(string value)
+    {
+      _value = value;
+    }
+
+    public override object? Evaluate(IReadOnlyDictionary<string, object?> row)
+      => _value;
+  }
+
+  private sealed class FunctionNode : Node
+  {
+    private readonly string _name;
+    private readonly Node _argument;
+    private readonly ExpressionEvaluator _evaluator;
+
+    public FunctionNode(string name, Node argument, ExpressionEvaluator evaluator)
+    {
+      _name = name;
+      _argument = argument;
+      _evaluator = evaluator;
+    }
+
+    public override object? Evaluate(IReadOnlyDictionary<string, object?> row)
+    {
+      var input = FormatValue(_argument.Evaluate(row));
+      return _evaluator.Invoke(_name, input);
+    }
+  }
+
+  private sealed class ConcatNode : Node
+  {
+    private readonly Node _left;
+    private readonly Node _right;
+
+    public ConcatNode(Node left, Node right)
+    {
+      _left = left;
+      _right = right;
+    }
+
+    public override object? Evaluate(IReadOnlyDictionary<string, object?> row)
+    {
+      var leftValue = FormatValue(_left.Evaluate(row)) ?? string.Empty;
+      var rightValue = FormatValue(_right.Evaluate(row)) ?? string.Empty;
+      return leftValue + rightValue;
+    }
+  }
+}

--- a/src/demo/XBase.Demo.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/demo/XBase.Demo.Infrastructure/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using XBase.Demo.Infrastructure.Indexes;
 using XBase.Demo.Infrastructure.Recovery;
 using XBase.Demo.Infrastructure.Schema;
 using XBase.Demo.Infrastructure.Seed;
+using XBase.Expressions.Evaluation;
 
 namespace XBase.Demo.Infrastructure;
 
@@ -27,6 +28,7 @@ public static class ServiceCollectionExtensions
     services.AddLogging(builder => builder.AddDebug());
     services.AddSingleton<DbfTableLoader>();
     services.AddSingleton<DbfCursorFactory>();
+    services.AddSingleton<ExpressionEvaluator>();
     services.AddSingleton<ITableCatalogService, FileSystemTableCatalogService>();
     services.AddSingleton<ITablePageService, DbfTablePageService>();
     services.AddSingleton<ISchemaDdlService, TemplateSchemaDdlService>();

--- a/tests/XBase.Demo.App.Tests/ShellViewModelTests.cs
+++ b/tests/XBase.Demo.App.Tests/ShellViewModelTests.cs
@@ -34,7 +34,7 @@ public sealed class ShellViewModelTests
       Assert.Contains(viewModel.TelemetryEvents, evt => evt.Name == "CatalogLoaded");
       Assert.Contains(viewModel.TelemetryEvents, evt => evt.Name == "TablePreviewLoaded");
 
-      Assert.Equal(0, viewModel.TablePage.TotalCount);
+      Assert.Equal(3, viewModel.TablePage.TotalCount);
       Assert.Equal(25, viewModel.TablePage.PageSize);
       Assert.Equal(0, viewModel.TablePage.PageNumber);
       Assert.Contains("Page 1", viewModel.TablePage.Summary, StringComparison.Ordinal);

--- a/tests/XBase.Demo.App.Tests/TempCatalog.cs
+++ b/tests/XBase.Demo.App.Tests/TempCatalog.cs
@@ -1,11 +1,20 @@
 using System;
+using System.Buffers.Binary;
 using System.IO;
+using System.Text;
 
 namespace XBase.Demo.App.Tests;
 
 internal sealed class TempCatalog : IDisposable
 {
   private readonly DirectoryInfo _directory;
+  private static readonly SampleRecord[] SampleRecords =
+  {
+    new("Alpha", false),
+    new("Omega", false),
+    new("Discarded", true),
+    new("Beta", false)
+  };
 
   public TempCatalog()
   {
@@ -19,7 +28,7 @@ internal sealed class TempCatalog : IDisposable
     ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
 
     var tablePath = System.IO.Path.Combine(Path, tableName + ".dbf");
-    File.WriteAllBytes(tablePath, Array.Empty<byte>());
+    WriteSampleDbf(tablePath);
 
     if (addPlaceholderIndex)
     {
@@ -47,4 +56,50 @@ internal sealed class TempCatalog : IDisposable
       // best effort cleanup
     }
   }
+
+  private static void WriteSampleDbf(string path)
+  {
+    Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path)!);
+    using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
+
+    Span<byte> header = stackalloc byte[32];
+    header.Clear();
+    header[0] = 0x03;
+    var today = DateTime.UtcNow;
+    header[1] = (byte)Math.Clamp(today.Year - 1900, 0, 255);
+    header[2] = (byte)Math.Clamp(today.Month, 1, 12);
+    header[3] = (byte)Math.Clamp(today.Day, 1, 31);
+    BinaryPrimitives.WriteUInt32LittleEndian(header[4..8], (uint)SampleRecords.Length);
+    BinaryPrimitives.WriteUInt16LittleEndian(header[8..10], 65);
+    BinaryPrimitives.WriteUInt16LittleEndian(header[10..12], 11);
+    stream.Write(header);
+
+    Span<byte> fieldDescriptor = stackalloc byte[32];
+    fieldDescriptor.Clear();
+    Encoding.ASCII.GetBytes("NAME").CopyTo(fieldDescriptor);
+    fieldDescriptor[11] = (byte)'C';
+    fieldDescriptor[16] = 10;
+    stream.Write(fieldDescriptor);
+
+    stream.WriteByte(0x0D);
+
+    foreach (var record in SampleRecords)
+    {
+      stream.WriteByte(record.Deleted ? (byte)'*' : (byte)' ');
+      var buffer = new byte[10];
+      var nameBytes = Encoding.ASCII.GetBytes(record.Name);
+      var length = Math.Min(nameBytes.Length, buffer.Length);
+      Array.Copy(nameBytes, buffer, length);
+      for (var index = length; index < buffer.Length; index++)
+      {
+        buffer[index] = 0x20;
+      }
+
+      stream.Write(buffer);
+    }
+
+    stream.WriteByte(0x1A);
+  }
+
+  private readonly record struct SampleRecord(string Name, bool Deleted);
 }


### PR DESCRIPTION
## Summary
- replace the demo index lifecycle placeholder with a DBF-aware implementation that materializes JSON index artifacts including statistics and signatures
- add an index expression compiler and surface the recorded metadata through the catalog service and UI view models
- refresh demo tests with seeded DBF fixtures and assertions that validate the richer index content

## Testing
- dotnet test xBase.sln -c Release

------
https://chatgpt.com/codex/tasks/task_e_68ddb430c1f8832297f260403b3fb1ff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Index files now include metadata (expression, signature, record statistics) and a deterministic signature for integrity.
  - App UI shows record counts (active/total when available) and a short signature preview.
  - Index keys can be defined via expressions for flexible sorting and lookup.

- Improvements
  - More reliable index creation with deterministic ordering and enhanced error handling.
  - Catalog view now reflects index metadata for faster insight.

- Tests
  - Added validations for generated index artifacts and catalog metadata.
  - Updated sample data generation and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->